### PR TITLE
REFACTOR queryParams names

### DIFF
--- a/src/features/brp/service.ts
+++ b/src/features/brp/service.ts
@@ -35,7 +35,7 @@ export function useBrpService() {
     postcode: string,
     huisnummer: string
   ) => {
-    const url = `${brpBaseUri}?verblijfplaats__postcode=${postcode}&verblijfplaats__huisnummer=${huisnummer}&extend[]=all`;
+    const url = `${brpBaseUri}?verblijfplaats.postcode=${postcode}&verblijfplaats.huisnummer=${huisnummer}&extend[]=all`;
 
     return fetchLoggedIn(url)
       .then((r) => {

--- a/src/features/zaaksysteem/service.ts
+++ b/src/features/zaaksysteem/service.ts
@@ -65,7 +65,7 @@ export function useZaaksysteemService() {
     const getFindByBsnURL = () => {
       if (!bsn.value) return "";
 
-      return `${zaaksysteemBaseUri}?rollen__betrokkeneIdentificatie__inpBsn=${bsn.value}&extend[]=all`;
+      return `${zaaksysteemBaseUri}?rollen.betrokkeneIdentificatie.inpBsn=${bsn.value}&extend[]=all`;
     };
 
     const getZaakByBsn = (url: string): Promise<Paginated<Zaak>> =>


### PR DESCRIPTION
The gateway expects (after new rollout) this refactored `queryParams` syntax.