### PR TITLE
REFACTOR dateModified params

### DIFF
--- a/src/features/werkbericht/service.ts
+++ b/src/features/werkbericht/service.ts
@@ -71,7 +71,9 @@ function parseWerkbericht(
     : ["onbekend"];
 
   const dateCreated = parseDateStrWithTimezone(jsonObject.date);
-  const dateModified = parseDateStrWithTimezone(jsonObject.modified);
+  const dateModified = parseDateStrWithTimezone(
+    jsonObject["x-commongateway-metadata"].dateModified
+  );
   const dateLatest = maxDate([dateCreated, dateModified]);
 
   let dateRead = jsonObject["x-commongateway-metadata"]?.dateRead;
@@ -165,6 +167,8 @@ export function useWerkberichten(
     ];
 
     params.push(["limit", "10"]);
+    params.push(["order[_dateModified]", "desc"]);
+    params.push(["extend[]", "x-commongateway-metadata.dateModified"]);
 
     if (typeId) {
       params.push(["openpub-type", typeId.toString()]);


### PR DESCRIPTION
Fix voor het sorteren van nieuwsberichten en werkinstructies.

**Note:** doordat de sync van wp  naar de gateway nog issues heeft klopt deze sortering niet voor oudere berichten. Nieuwere berichten gaan wel goed. Alle berichten gaan goed wanneer de sync weer werkt.