### PR TITLE
feature/#147_test_feedback

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -145,11 +145,11 @@ const route = useRoute();
   --section-width-small: 20rem;
   --section-width-large: 60rem;
 
-  --spacing-default: 1rem;
+  --spacing-extrasmall: 0.25rem;
   --spacing-small: 0.5rem;
+  --spacing-default: 1rem;
   --spacing-large: 2rem;
   --spacing-extralarge: 6rem;
-  --spacing-extrasmall: 0.25rem;
 
   --header-height: 6rem;
   --text-margin: 1.5rem;

--- a/src/features/klant/KlantAanmaken.vue
+++ b/src/features/klant/KlantAanmaken.vue
@@ -96,7 +96,7 @@ import { createKlant } from "../contactverzoek";
 import SimpleSpinner from "../../components/SimpleSpinner.vue";
 import { useContactmomentStore } from "@/stores/contactmoment";
 import ApplicationMessage from "../../components/ApplicationMessage.vue";
-import router from "@/router";
+import { useRouter } from "vue-router";
 
 const props = defineProps<{
   handleCancel: () => void;
@@ -110,6 +110,8 @@ const formData = ref({
   email: "",
   telefoonnummer: "",
 });
+
+const router = useRouter();
 
 const contactmomentStore = useContactmomentStore();
 

--- a/src/features/klant/KlantAanmaken.vue
+++ b/src/features/klant/KlantAanmaken.vue
@@ -96,6 +96,7 @@ import { createKlant } from "../contactverzoek";
 import SimpleSpinner from "../../components/SimpleSpinner.vue";
 import { useContactmomentStore } from "@/stores/contactmoment";
 import ApplicationMessage from "../../components/ApplicationMessage.vue";
+import router from "@/router";
 
 const props = defineProps<{
   handleCancel: () => void;
@@ -139,9 +140,14 @@ const submit = async () => {
     telefoonnummers: [{ telefoonnummer: formData.value.telefoonnummer }],
     emails: [{ email: formData.value.email }],
   }).then((res) => {
-    contactmomentStore.setKlant(res);
+    contactmomentStore.setKlant({
+      ...res,
+      telefoonnummers: res.embedded.telefoonnummers,
+      emails: res.embedded.emails,
+    });
     savingKlant.value = false;
     props.handleSaveCallback();
+    router.push({ name: "klantDetail", params: { id: res.id } });
   });
 };
 </script>

--- a/src/features/klant/KlantZoeker.vue
+++ b/src/features/klant/KlantZoeker.vue
@@ -27,7 +27,7 @@
       type="button"
       class="klant-aanmaken icon-before plus utrecht-button utrecht-button--secondary-action"
     >
-      Klant aanmaken
+      <span>Klant aanmaken</span>
     </button>
   </nav>
 
@@ -128,6 +128,10 @@ nav {
 
   .klant-aanmaken {
     display: flex;
+
+    span {
+      margin-inline-start: var(--spacing-extrasmall);
+    }
   }
 }
 

--- a/src/views/AfhandelingView.vue
+++ b/src/views/AfhandelingView.vue
@@ -28,7 +28,7 @@
             :key="record.klant.id"
           >
             <label>
-              <span>{{
+              <span v-if="record.klant.voornaam || record.klant.achternaam">{{
                 [
                   record.klant.voornaam,
                   record.klant.voorvoegselAchternaam,
@@ -36,6 +36,14 @@
                 ]
                   .filter((x) => x)
                   .join(" ")
+              }}</span>
+              <span v-else>{{
+                [
+                  record.klant.emails[0].email,
+                  record.klant.telefoonnummers[0].telefoonnummer,
+                ]
+                  .filter((x) => x)
+                  .join(", ")
               }}</span>
               <input type="checkbox" v-model="record.shouldStore" />
             </label>


### PR DESCRIPTION
In deze pull request:

- Wordt een aangemaakte klant direct geselecteerd én de e-mailadressen en telefoonnummers direct gevuld;
- Worden gerelateerde klanten in de afhangeling view die géén naam of achternaam hebben getoond met hun (1e) e-mailadres en/of (1e) telefoonnummer;
- Visuele edit op de Klant aanmaken button (besproken met Gina).

Note: aanpassingen zijn besproken met Sytske en meer informatie is te vinden in #147 