### PR TITLE
Feature/#104 zaak detail

### DIFF
--- a/src/components/TabsComponent.vue
+++ b/src/components/TabsComponent.vue
@@ -108,11 +108,6 @@ watch(
   --tab-spacing: var(--spacing-default);
   padding-inline: var(--spacing-large);
   padding-block: var(--spacing-default);
-  margin-inline-start: calc(-1 * var(--tab-spacing));
-
-  //verschilt per toepassing..heleaal weg of configurabel maken
-  // border-start-end-radius: var(--radius-default);
-  // border-start-start-radius: var(--radius-default);
 }
 
 [role="tabpanel"],

--- a/src/features/zaaksysteem/ZaakDetails.vue
+++ b/src/features/zaaksysteem/ZaakDetails.vue
@@ -9,11 +9,18 @@
 
     <tabs-component v-model="activeTab">
       <template #[Tabs.algemeen]> <zaak-algemeen :zaak="zaak" /> </template>
-      <template #[Tabs.documenten]> Documenten </template>
-      <template #[Tabs.betrokkenen]> Betrokkenen </template>
+
+      <template #[Tabs.documenten]> <zaak-documenten :zaak="zaak" /> </template>
+
+      <template #[Tabs.betrokkenen]>
+        <zaak-betrokkenen :zaak="zaak" />
+      </template>
+
       <template #[Tabs.contactmomenten]> Contactmomenten </template>
-      <template #[Tabs.historie]> Historie </template>
-      <template #[Tabs.locatie]> Locatie </template>
+
+      <template #[Tabs.historie]> <zaak-historie :zaak="zaak" /> </template>
+
+      <template #[Tabs.locatie]> <zaak-locatie :zaak="zaak" /> </template>
     </tabs-component>
 
     <div class="toelichting">
@@ -29,6 +36,10 @@ import { UtrechtHeading } from "@utrecht/web-component-library-vue";
 import ZaakToelichting from "./components/ZaakToelichting.vue";
 import TabsComponent from "../../components/TabsComponent.vue";
 import ZaakAlgemeen from "./components/ZaakAlgemeen.vue";
+import ZaakDocumenten from "./components/ZaakDocumenten.vue";
+import ZaakBetrokkenen from "./components/ZaakBetrokkenen.vue";
+import ZaakHistorie from "./components/ZaakHistorie.vue";
+import ZaakLocatie from "./components/ZaakLocatie.vue";
 
 defineProps<{
   zaak: ZaakDetails;

--- a/src/features/zaaksysteem/ZaakDetails.vue
+++ b/src/features/zaaksysteem/ZaakDetails.vue
@@ -7,6 +7,15 @@
       <router-link :to="{ name: 'zaken' }">{{ "< Ga terug" }}</router-link>
     </div>
 
+    <tabs-component v-model="activeTab">
+      <template #[Tabs.algemeen]> Algemeen </template>
+      <template #[Tabs.documenten]> Documenten </template>
+      <template #[Tabs.betrokkenen]> Betrokkenen </template>
+      <template #[Tabs.contactmomenten]> Contactmomenten </template>
+      <template #[Tabs.historie]> Historie </template>
+      <template #[Tabs.locatie]> Locatie </template>
+    </tabs-component>
+
     <div class="toelichting">
       <zaak-toelichting :zaak="zaak" />
     </div>
@@ -14,14 +23,25 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps } from "vue";
+import { defineProps, ref } from "vue";
 import type { ZaakDetails } from "./types";
 import { UtrechtHeading } from "@utrecht/web-component-library-vue";
 import ZaakToelichting from "./components/ZaakToelichting.vue";
+import TabsComponent from "../../components/TabsComponent.vue";
 
 defineProps<{
   zaak: ZaakDetails;
 }>();
+
+enum Tabs {
+  algemeen = "Algemeen",
+  documenten = "Documenten",
+  betrokkenen = "Betrokkenen",
+  contactmomenten = "Contactmomenten",
+  historie = "Historie",
+  locatie = "Locatie",
+}
+const activeTab = ref(Tabs.algemeen);
 </script>
 
 <style scoped lang="scss">

--- a/src/features/zaaksysteem/ZaakDetails.vue
+++ b/src/features/zaaksysteem/ZaakDetails.vue
@@ -8,98 +8,20 @@
     </div>
 
     <div class="toelichting">
-      <utrecht-heading :level="3" model-value>
-        <div class="toelichting-heading">
-          <span>Toelichting</span>
-          <button
-            v-if="!isEditingToelichting"
-            @click="toggleEditingToelichting"
-            title="Bewerken"
-            class="icon-after pen"
-          />
-          <simple-spinner class="spinner" v-if="formIsLoading" />
-        </div>
-      </utrecht-heading>
-
-      <form class="new-note" @submit.prevent="submit">
-        <textarea
-          required
-          :disabled="!isEditingToelichting"
-          class="utrecht-textarea utrecht-textarea--html-textarea"
-          rows="10"
-          placeholder="Schrijf een nieuwe notitie bij de zaak"
-          v-model="toelichtingInputValue"
-        ></textarea>
-
-        <menu v-if="isEditingToelichting">
-          <utrecht-button
-            :disabled="formIsLoading"
-            modelValue
-            @click="toggleEditingToelichting"
-            type="button"
-            appearance="secondary-action-button"
-            >Annuleren</utrecht-button
-          >
-          <button
-            :disabled="formIsLoading"
-            class="utrecht-button utrecht-button--submit"
-            type="submit"
-          >
-            Opslaan
-          </button>
-        </menu>
-      </form>
+      <zaak-toelichting :zaak="zaak" />
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { defineProps, ref } from "vue";
+import { defineProps } from "vue";
 import type { ZaakDetails } from "./types";
-import {
-  UtrechtHeading,
-  UtrechtButton,
-} from "@utrecht/web-component-library-vue";
-import { toast } from "@/stores/toast";
-import { updateToelichting } from "./service";
-import SimpleSpinner from "@/components/SimpleSpinner.vue";
-import { useContactmomentStore } from "@/stores/contactmoment";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+import ZaakToelichting from "./components/ZaakToelichting.vue";
 
-const props = defineProps<{
+defineProps<{
   zaak: ZaakDetails;
 }>();
-
-const contactmomentStore = useContactmomentStore();
-
-const formIsLoading = ref<boolean>(false);
-const isEditingToelichting = ref<boolean>(false);
-const toelichtingInputValue = ref<string>(props.zaak.toelichting);
-
-const toggleEditingToelichting = () => {
-  isEditingToelichting.value = !isEditingToelichting.value;
-};
-
-const submit = async () => {
-  formIsLoading.value = true;
-
-  updateToelichting(props.zaak, toelichtingInputValue.value)
-    .then((res) => {
-      toast({ text: "De notitie is opgeslagen." });
-      contactmomentStore.addZaak(res);
-    })
-    .catch(() => {
-      toelichtingInputValue.value = props.zaak.toelichting;
-
-      toast({
-        type: "error",
-        text: "Oeps het lukt niet om deze notitie op te slaan. Probeer het later opnieuw.",
-      });
-    })
-    .finally(() => {
-      toggleEditingToelichting();
-      formIsLoading.value = false;
-    });
-};
 </script>
 
 <style scoped lang="scss">

--- a/src/features/zaaksysteem/ZaakDetails.vue
+++ b/src/features/zaaksysteem/ZaakDetails.vue
@@ -8,19 +8,29 @@
     </div>
 
     <tabs-component v-model="activeTab">
-      <template #[Tabs.algemeen]> <zaak-algemeen :zaak="zaak" /> </template>
+      <template #[Tabs.algemeen]>
+        <zaak-algemeen :zaak="zaak" />
+      </template>
 
-      <template #[Tabs.documenten]> <zaak-documenten :zaak="zaak" /> </template>
+      <template #[Tabs.documenten]>
+        <zaak-documenten :zaak="zaak" />
+      </template>
 
       <template #[Tabs.betrokkenen]>
         <zaak-betrokkenen :zaak="zaak" />
       </template>
 
-      <template #[Tabs.contactmomenten]> Contactmomenten </template>
+      <template #[Tabs.contactmomenten]>
+        <zaak-contactmomenten :zaak="zaak" />
+      </template>
 
-      <template #[Tabs.historie]> <zaak-historie :zaak="zaak" /> </template>
+      <template #[Tabs.historie]>
+        <zaak-historie :zaak="zaak" />
+      </template>
 
-      <template #[Tabs.locatie]> <zaak-locatie :zaak="zaak" /> </template>
+      <template #[Tabs.locatie]>
+        <zaak-locatie :zaak="zaak" />
+      </template>
     </tabs-component>
 
     <div class="toelichting">
@@ -40,6 +50,7 @@ import ZaakDocumenten from "./components/ZaakDocumenten.vue";
 import ZaakBetrokkenen from "./components/ZaakBetrokkenen.vue";
 import ZaakHistorie from "./components/ZaakHistorie.vue";
 import ZaakLocatie from "./components/ZaakLocatie.vue";
+import ZaakContactmomenten from "./components/ZaakContactmomenten.vue";
 
 defineProps<{
   zaak: ZaakDetails;

--- a/src/features/zaaksysteem/ZaakDetails.vue
+++ b/src/features/zaaksysteem/ZaakDetails.vue
@@ -8,7 +8,7 @@
     </div>
 
     <tabs-component v-model="activeTab">
-      <template #[Tabs.algemeen]> Algemeen </template>
+      <template #[Tabs.algemeen]> <zaak-algemeen :zaak="zaak" /> </template>
       <template #[Tabs.documenten]> Documenten </template>
       <template #[Tabs.betrokkenen]> Betrokkenen </template>
       <template #[Tabs.contactmomenten]> Contactmomenten </template>
@@ -28,6 +28,7 @@ import type { ZaakDetails } from "./types";
 import { UtrechtHeading } from "@utrecht/web-component-library-vue";
 import ZaakToelichting from "./components/ZaakToelichting.vue";
 import TabsComponent from "../../components/TabsComponent.vue";
+import ZaakAlgemeen from "./components/ZaakAlgemeen.vue";
 
 defineProps<{
   zaak: ZaakDetails;

--- a/src/features/zaaksysteem/components/ZaakAlgemeen.vue
+++ b/src/features/zaaksysteem/components/ZaakAlgemeen.vue
@@ -29,23 +29,23 @@
       <ul>
         <li>
           <span class="label">Indiendatum</span>
-          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+          <span class="value">{{ formatDateOnly(zaak.indienDatum) }}</span>
         </li>
         <li>
           <span class="label">Registratiedatum</span>
-          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+          <span class="value">{{ formatDateOnly(zaak.registratieDatum) }}</span>
         </li>
         <li>
           <span class="label">Startdatum</span>
-          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+          <span class="value">{{ formatDateOnly(zaak.startdatum) }}</span>
         </li>
         <li>
           <span class="label">Streefdatum</span>
-          <span class="value">{{ formatDateAndTime(zaak.streefDatum) }}</span>
+          <span class="value">{{ formatDateOnly(zaak.streefDatum) }}</span>
         </li>
         <li>
           <span class="label">Fatale datum</span>
-          <span class="value">{{ formatDateAndTime(zaak.fataleDatum) }}</span>
+          <span class="value">{{ formatDateOnly(zaak.fataleDatum) }}</span>
         </li>
       </ul>
     </div>
@@ -56,13 +56,11 @@
 import { defineProps } from "vue";
 import type { ZaakDetails } from "./../types";
 import { UtrechtHeading } from "@utrecht/web-component-library-vue";
-import { formatDateAndTime } from "@/helpers/date";
+import { formatDateOnly } from "@/helpers/date";
 
-const props = defineProps<{
+defineProps<{
   zaak: ZaakDetails;
 }>();
-
-console.log({ zaak: props.zaak });
 </script>
 
 <style scoped lang="scss">

--- a/src/features/zaaksysteem/components/ZaakAlgemeen.vue
+++ b/src/features/zaaksysteem/components/ZaakAlgemeen.vue
@@ -85,7 +85,7 @@ section {
 }
 
 ul > li:not(:last-child) {
-  margin-block-end: var(--spacing-small);
+  margin-block-end: var(--spacing-default);
 }
 
 li {

--- a/src/features/zaaksysteem/components/ZaakAlgemeen.vue
+++ b/src/features/zaaksysteem/components/ZaakAlgemeen.vue
@@ -1,0 +1,108 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Algemeen</utrecht-heading>
+
+    <div class="content">
+      <ul>
+        <li>
+          <span class="label">Zaaknummer</span>
+          <span class="value">{{ zaak.identificatie }}</span>
+        </li>
+        <li>
+          <span class="label">Zaaktype</span>
+          <span class="value">{{ zaak.zaaktypeLabel }}</span>
+        </li>
+        <li>
+          <span class="label">Status</span>
+          <span class="value">{{ zaak.status }}</span>
+        </li>
+        <li>
+          <span class="label">Behandelaar</span>
+          <span class="value">{{ zaak.behandelaar }}</span>
+        </li>
+        <li>
+          <span class="label">Aanvrager</span>
+          <span class="value">{{ zaak.aanvrager }}</span>
+        </li>
+      </ul>
+
+      <ul>
+        <li>
+          <span class="label">Indiendatum</span>
+          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+        </li>
+        <li>
+          <span class="label">Registratiedatum</span>
+          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+        </li>
+        <li>
+          <span class="label">Startdatum</span>
+          <span class="value">{{ formatDateAndTime(zaak.startdatum) }}</span>
+        </li>
+        <li>
+          <span class="label">Streefdatum</span>
+          <span class="value">{{ formatDateAndTime(zaak.streefDatum) }}</span>
+        </li>
+        <li>
+          <span class="label">Fatale datum</span>
+          <span class="value">{{ formatDateAndTime(zaak.fataleDatum) }}</span>
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+import { formatDateAndTime } from "@/helpers/date";
+
+const props = defineProps<{
+  zaak: ZaakDetails;
+}>();
+
+console.log({ zaak: props.zaak });
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+
+.content {
+  display: flex;
+
+  > * {
+    flex: 1;
+  }
+
+  > *:not(:last-child) {
+    margin-inline-end: var(--spacing-large);
+  }
+}
+
+ul > li:not(:last-child) {
+  margin-block-end: var(--spacing-small);
+}
+
+li {
+  display: flex;
+
+  & > .label {
+    flex: 1;
+    max-width: 175px;
+  }
+  & > .value {
+    flex: 1;
+  }
+}
+
+.label {
+  font-weight: 600;
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakBetrokkenen.vue
+++ b/src/features/zaaksysteem/components/ZaakBetrokkenen.vue
@@ -2,7 +2,7 @@
   <section>
     <utrecht-heading :level="2" modelValue>Betrokkenen</utrecht-heading>
 
-    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+    <span>Dit tabblad is nog in ontwikkeling.</span>
   </section>
 </template>
 

--- a/src/features/zaaksysteem/components/ZaakBetrokkenen.vue
+++ b/src/features/zaaksysteem/components/ZaakBetrokkenen.vue
@@ -1,0 +1,27 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Betrokkenen</utrecht-heading>
+
+    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+
+defineProps<{
+  zaak: ZaakDetails;
+}>();
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakContactmomenten.vue
+++ b/src/features/zaaksysteem/components/ZaakContactmomenten.vue
@@ -4,11 +4,7 @@
 
     <simple-spinner v-if="contactmomenten.loading" />
 
-    <span v-if="contactmomenten.error">
-      Er ging iets mis. Probeer het later nog eens.
-    </span>
-
-    <template v-if="contactmomenten.success">
+    <template v-if="contactmomenten.success && contactmomenten.data.length">
       <table>
         <thead>
           <tr>
@@ -31,6 +27,14 @@
         </tbody>
       </table>
     </template>
+
+    <span v-if="contactmomenten.success && !contactmomenten.data.length"
+      >Geen contactmomenten gevonden.</span
+    >
+
+    <span v-if="contactmomenten.error">
+      Er ging iets mis. Probeer het later nog eens.
+    </span>
   </section>
 </template>
 

--- a/src/features/zaaksysteem/components/ZaakContactmomenten.vue
+++ b/src/features/zaaksysteem/components/ZaakContactmomenten.vue
@@ -1,0 +1,91 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Contactmomenten</utrecht-heading>
+
+    <simple-spinner v-if="contactmomenten.loading" />
+
+    <span v-if="contactmomenten.error">
+      Er ging iets mis. Probeer het later nog eens.
+    </span>
+
+    <template v-if="contactmomenten.success">
+      <table>
+        <thead>
+          <tr>
+            <th>Datum</th>
+            <th>Medewerker</th>
+            <th>Kanaal</th>
+            <th>Gespreksresultaat</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="contactmoment in contactmomenten.data"
+            :key="contactmoment.id"
+          >
+            <td>{{ formatDateOnly(new Date(contactmoment.startdatum)) }}</td>
+            <td>Onbekend</td>
+            <td>{{ contactmoment.kanaal }}</td>
+            <td>{{ contactmoment.resultaat }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+import { useZaaksysteemService } from "../service";
+import SimpleSpinner from "../../../components/SimpleSpinner.vue";
+import { formatDateOnly } from "@/helpers/date";
+
+const props = defineProps<{
+  zaak: ZaakDetails;
+}>();
+
+const zaaksysteemService = useZaaksysteemService();
+
+const contactmomenten = zaaksysteemService.getContactmomentenByZaak(
+  props.zaak.self
+);
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+
+table {
+  width: 100%;
+
+  thead {
+    color: var(--color-white);
+    background: var(--color-tertiary);
+
+    th {
+      font-weight: normal;
+    }
+  }
+
+  tr {
+    display: flex;
+    padding: var(--spacing-default);
+
+    & > * {
+      flex: 1;
+    }
+  }
+
+  tbody > tr {
+    background: var(--color-white);
+    border-bottom: 2px solid var(--color-tertiary);
+  }
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakDocumenten.vue
+++ b/src/features/zaaksysteem/components/ZaakDocumenten.vue
@@ -1,0 +1,27 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Documenten</utrecht-heading>
+
+    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+
+defineProps<{
+  zaak: ZaakDetails;
+}>();
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakDocumenten.vue
+++ b/src/features/zaaksysteem/components/ZaakDocumenten.vue
@@ -2,7 +2,7 @@
   <section>
     <utrecht-heading :level="2" modelValue>Documenten</utrecht-heading>
 
-    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+    <span>Dit tabblad is nog in ontwikkeling.</span>
   </section>
 </template>
 

--- a/src/features/zaaksysteem/components/ZaakHistorie.vue
+++ b/src/features/zaaksysteem/components/ZaakHistorie.vue
@@ -1,0 +1,27 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Historie</utrecht-heading>
+
+    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+
+defineProps<{
+  zaak: ZaakDetails;
+}>();
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakHistorie.vue
+++ b/src/features/zaaksysteem/components/ZaakHistorie.vue
@@ -2,7 +2,7 @@
   <section>
     <utrecht-heading :level="2" modelValue>Historie</utrecht-heading>
 
-    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+    <span>Dit tabblad is nog in ontwikkeling.</span>
   </section>
 </template>
 

--- a/src/features/zaaksysteem/components/ZaakLocatie.vue
+++ b/src/features/zaaksysteem/components/ZaakLocatie.vue
@@ -2,7 +2,7 @@
   <section>
     <utrecht-heading :level="2" modelValue>Locatie</utrecht-heading>
 
-    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+    <span>Dit tabblad is nog in ontwikkeling.</span>
   </section>
 </template>
 

--- a/src/features/zaaksysteem/components/ZaakLocatie.vue
+++ b/src/features/zaaksysteem/components/ZaakLocatie.vue
@@ -1,0 +1,27 @@
+<template>
+  <section>
+    <utrecht-heading :level="2" modelValue>Locatie</utrecht-heading>
+
+    <span>Dit tabblad heeft nog doorontwikkeling nodig.</span>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+import type { ZaakDetails } from "./../types";
+import { UtrechtHeading } from "@utrecht/web-component-library-vue";
+
+defineProps<{
+  zaak: ZaakDetails;
+}>();
+</script>
+
+<style scoped lang="scss">
+section {
+  padding: var(--spacing-large);
+
+  & > *:not(:last-child) {
+    margin-block-end: var(--spacing-large);
+  }
+}
+</style>

--- a/src/features/zaaksysteem/components/ZaakToelichting.vue
+++ b/src/features/zaaksysteem/components/ZaakToelichting.vue
@@ -93,6 +93,8 @@ const submit = async () => {
 
 <style scoped lang="scss">
 .edit-toelichting {
+  max-width: 600px;
+
   > *:not(:last-child) {
     margin-block-end: var(--spacing-small);
   }

--- a/src/features/zaaksysteem/components/ZaakToelichting.vue
+++ b/src/features/zaaksysteem/components/ZaakToelichting.vue
@@ -1,0 +1,124 @@
+<template>
+  <utrecht-heading :level="3" model-value>
+    <div class="toelichting-heading">
+      <span>Toelichting</span>
+      <button
+        v-if="!isEditingToelichting"
+        @click="toggleEditingToelichting"
+        title="Bewerken"
+        class="icon-after pen"
+      />
+      <simple-spinner class="spinner" v-if="formIsLoading" />
+    </div>
+  </utrecht-heading>
+
+  <form class="edit-toelichting" @submit.prevent="submit">
+    <textarea
+      required
+      :disabled="!isEditingToelichting"
+      class="utrecht-textarea utrecht-textarea--html-textarea"
+      rows="10"
+      placeholder="Schrijf een nieuwe notitie bij de zaak"
+      v-model="toelichtingInputValue"
+    ></textarea>
+
+    <menu v-if="isEditingToelichting">
+      <utrecht-button
+        :disabled="formIsLoading"
+        modelValue
+        @click="toggleEditingToelichting"
+        type="button"
+        appearance="secondary-action-button"
+        >Annuleren</utrecht-button
+      >
+      <button
+        :disabled="formIsLoading"
+        class="utrecht-button utrecht-button--submit"
+        type="submit"
+      >
+        Opslaan
+      </button>
+    </menu>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { defineProps, ref } from "vue";
+import type { ZaakDetails } from "./../types";
+import {
+  UtrechtHeading,
+  UtrechtButton,
+} from "@utrecht/web-component-library-vue";
+import { toast } from "@/stores/toast";
+import { updateToelichting } from "./../service";
+import SimpleSpinner from "@/components/SimpleSpinner.vue";
+import { useContactmomentStore } from "@/stores/contactmoment";
+
+const props = defineProps<{
+  zaak: ZaakDetails;
+}>();
+
+const contactmomentStore = useContactmomentStore();
+
+const formIsLoading = ref<boolean>(false);
+const isEditingToelichting = ref<boolean>(false);
+const toelichtingInputValue = ref<string>(props.zaak.toelichting);
+
+const toggleEditingToelichting = () => {
+  isEditingToelichting.value = !isEditingToelichting.value;
+};
+
+const submit = async () => {
+  formIsLoading.value = true;
+
+  updateToelichting(props.zaak, toelichtingInputValue.value)
+    .then((res) => {
+      toast({ text: "De notitie is opgeslagen." });
+      contactmomentStore.addZaak(res);
+    })
+    .catch(() => {
+      toelichtingInputValue.value = props.zaak.toelichting;
+
+      toast({
+        type: "error",
+        text: "Oeps het lukt niet om deze notitie op te slaan. Probeer het later opnieuw.",
+      });
+    })
+    .finally(() => {
+      toggleEditingToelichting();
+      formIsLoading.value = false;
+    });
+};
+</script>
+
+<style scoped lang="scss">
+.edit-toelichting {
+  > *:not(:last-child) {
+    margin-block-end: var(--spacing-small);
+  }
+
+  menu {
+    display: flex;
+    gap: var(--spacing-small);
+    float: right;
+  }
+}
+
+.toelichting-heading {
+  display: flex;
+
+  button {
+    all: unset;
+    margin-inline-start: var(--spacing-default);
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+
+.spinner {
+  font-size: 16px;
+  margin-inline-start: var(--spacing-default);
+}
+</style>

--- a/src/features/zaaksysteem/service.ts
+++ b/src/features/zaaksysteem/service.ts
@@ -10,9 +10,13 @@ import {
 import type { Zaak } from "./types";
 import type { ZaakDetails } from "./types";
 
-const getBehandelaarName = (zaak: any): string => {
+type Roltype = "behandelaar" | "initiator";
+
+const getNamePerRoltype = (zaak: any, roltype: Roltype): string => {
   const behandelaar = zaak.embedded.rollen.find(
-    (rol: any) => rol.betrokkeneType === "medewerker"
+    (rol: any) =>
+      rol.betrokkeneType === "medewerker" &&
+      rol.omschrijvingGeneriek === roltype
   );
 
   const identificatie = behandelaar?.embedded?.betrokkeneIdentificatie;
@@ -43,7 +47,7 @@ function parseZaak(zaak: any): Zaak {
     registratiedatum: startdatum,
     status: zaak.embedded.status.statustoelichting,
     fataleDatum,
-    behandelaar: getBehandelaarName(zaak),
+    behandelaar: getNamePerRoltype(zaak, "behandelaar"),
     toelichting: zaak.toelichting,
   };
 }
@@ -107,11 +111,13 @@ export function useZaaksysteemService() {
             zaaktype: zaak.embedded.zaaktype.id,
             zaaktypeLabel: zaak.embedded.zaaktype.onderwerp,
             status: zaak.embedded.status.statustoelichting,
-            behandelaar: getBehandelaarName(zaak),
-            aanvrager: getBehandelaarName(zaak),
+            behandelaar: getNamePerRoltype(zaak, "behandelaar"),
+            aanvrager: getNamePerRoltype(zaak, "initiator"),
             startdatum: startdatum,
             fataleDatum: fataleDatum,
             streefDatum: streefDatum,
+            indienDatum: zaak.publicatiedatum ?? "Onbekend",
+            registratieDatum: new Date(zaak.registratiedatum),
           } as ZaakDetails;
         });
     }

--- a/src/features/zaaksysteem/service.ts
+++ b/src/features/zaaksysteem/service.ts
@@ -10,6 +10,22 @@ import {
 import type { Zaak } from "./types";
 import type { ZaakDetails } from "./types";
 
+const getBehandelaarName = (zaak: any): string => {
+  const behandelaar = zaak.embedded.rollen.find(
+    (rol: any) => rol.betrokkeneType === "medewerker"
+  );
+
+  const identificatie = behandelaar?.embedded?.betrokkeneIdentificatie;
+
+  if (!identificatie) return "Onbekend";
+
+  const voornaam = identificatie.voornamen ?? "";
+  const tussenvoegsel = identificatie.voorvoegselGeslachtsnaam ?? "";
+  const achternaam = identificatie.geslachtsnaam ?? "";
+
+  return `${voornaam} ${tussenvoegsel} ${achternaam}`;
+};
+
 function parseZaak(zaak: any): Zaak {
   const startdatum = new Date(zaak.startdatum);
   const fataleDatum = DateTime.fromJSDate(startdatum)
@@ -17,22 +33,6 @@ function parseZaak(zaak: any): Zaak {
       days: parseInt(zaak.embedded.zaaktype.doorlooptijd, 10),
     })
     .toJSDate();
-
-  const getBehandelaarName = (): string => {
-    const behandelaar = zaak.embedded.rollen.find(
-      (rol: any) => rol.betrokkeneType === "medewerker"
-    );
-
-    const identificatie = behandelaar?.embedded?.betrokkeneIdentificatie;
-
-    if (!identificatie) return "Onbekend";
-
-    const voornaam = identificatie.voornamen ?? "";
-    const tussenvoegsel = identificatie.voorvoegselGeslachtsnaam ?? "";
-    const achternaam = identificatie.geslachtsnaam ?? "";
-
-    return `${voornaam} ${tussenvoegsel} ${achternaam}`;
-  };
 
   return {
     identificatie: zaak.identificatie,
@@ -43,7 +43,7 @@ function parseZaak(zaak: any): Zaak {
     registratiedatum: startdatum,
     status: zaak.embedded.status.statustoelichting,
     fataleDatum,
-    behandelaar: getBehandelaarName(),
+    behandelaar: getBehandelaarName(zaak),
     toelichting: zaak.toelichting,
   };
 }
@@ -90,9 +90,28 @@ export function useZaaksysteemService() {
         .then(throwIfNotOk)
         .then((x) => x.json())
         .then((zaak) => {
+          const startdatum = new Date(zaak.startdatum);
+          const fataleDatum = DateTime.fromJSDate(startdatum)
+            .plus({
+              days: parseInt(zaak.embedded.zaaktype.doorlooptijd, 10),
+            })
+            .toJSDate();
+          const streefDatum = DateTime.fromJSDate(startdatum)
+            .plus({
+              days: parseInt(zaak.embedded.zaaktype.servicenorm, 10),
+            })
+            .toJSDate();
+
           return {
             ...zaak,
             zaaktype: zaak.embedded.zaaktype.id,
+            zaaktypeLabel: zaak.embedded.zaaktype.onderwerp,
+            status: zaak.embedded.status.statustoelichting,
+            behandelaar: getBehandelaarName(zaak),
+            aanvrager: getBehandelaarName(zaak),
+            startdatum: startdatum,
+            fataleDatum: fataleDatum,
+            streefDatum: streefDatum,
           } as ZaakDetails;
         });
     }

--- a/src/features/zaaksysteem/types.ts
+++ b/src/features/zaaksysteem/types.ts
@@ -14,6 +14,7 @@ export type ZaakDetails = {
   streefDatum: Date;
   indienDatum: Date;
   registratieDatum: Date;
+  self: string;
 };
 
 export interface Zaak {

--- a/src/features/zaaksysteem/types.ts
+++ b/src/features/zaaksysteem/types.ts
@@ -12,6 +12,8 @@ export type ZaakDetails = {
   aanvrager: string;
   fataleDatum: Date;
   streefDatum: Date;
+  indienDatum: Date;
+  registratieDatum: Date;
 };
 
 export interface Zaak {

--- a/src/features/zaaksysteem/types.ts
+++ b/src/features/zaaksysteem/types.ts
@@ -6,6 +6,12 @@ export type ZaakDetails = {
   bronorganisatie: string;
   verantwoordelijkeOrganisatie: string;
   zaaktype: string;
+  zaaktypeLabel: string;
+  status: string;
+  behandelaar: string;
+  aanvrager: string;
+  fataleDatum: Date;
+  streefDatum: Date;
 };
 
 export interface Zaak {


### PR DESCRIPTION
This pull request includes:

- Separation of zaak toelichtingen to its own component;
- Tabs layout in zaak detail page;
- Implementation of the tabs: _Algemeen_ and _Contactmomenten_;
- Dummy implementation of all other tabs.

Notes:

- The tabs _Documenten_ and _Historie_ still require content. However, this content is not (yet) available in the backend;
- The remaining tabs are intended to be this dummy implementation (verified with Gina and Hanneke);

I think we can review and merge this piece of functionality and implement the remaining tabs later.