### PR TITLE
REFACTOR shouldStore always active on search results

### DIFF
--- a/src/stores/contactmoment/index.ts
+++ b/src/stores/contactmoment/index.ts
@@ -153,10 +153,6 @@ export const useContactmomentStore = defineStore("contactmoment", {
     },
 
     addMedewerker(medewerker: any, url: string) {
-      this.huidigeVraag.medewerkers.forEach(
-        (m) => (m.shouldStore = m.medewerker.id === medewerker.id)
-      );
-
       const newMedewerkerIndex = this.huidigeVraag.medewerkers.findIndex(
         (m) => m.medewerker.id === medewerker.id
       );
@@ -168,7 +164,9 @@ export const useContactmomentStore = defineStore("contactmoment", {
             voornaam: medewerker.contact.voornaam,
             voorvoegselAchternaam: medewerker.contact.voorvoegselAchternaam,
             achternaam: medewerker.contact.achternaam,
-            emailadres: medewerker.contact.emailadres,
+            emailadres: medewerker.contact.emails
+              ? medewerker.contact.emails[0].email
+              : "",
             url,
           },
           shouldStore: true,
@@ -177,10 +175,6 @@ export const useContactmomentStore = defineStore("contactmoment", {
     },
 
     addKennisartikel(kennisartikel: any) {
-      this.huidigeVraag.kennisartikelen.forEach(
-        (k) => (k.shouldStore = k.kennisartikel.url === kennisartikel.url)
-      );
-
       const newKennisartikelIndex = this.huidigeVraag.kennisartikelen.findIndex(
         (k) => k.kennisartikel.url === kennisartikel.url
       );
@@ -199,10 +193,6 @@ export const useContactmomentStore = defineStore("contactmoment", {
     },
 
     addWebsite(website: Website) {
-      this.huidigeVraag.websites.forEach(
-        (w) => (w.shouldStore = w.website.url === website.url)
-      );
-
       const newWebsiteIndex = this.huidigeVraag.websites.findIndex(
         (w) => w.website.url === website.url
       );

--- a/src/views/AfhandelingView.vue
+++ b/src/views/AfhandelingView.vue
@@ -84,8 +84,10 @@
                       .filter((x) => x)
                       .join(" ")
                   }}
-                  ({{ record.medewerker.emailadres }})</span
-                >
+                  <span v-if="record.medewerker.emailadres"
+                    >({{ record.medewerker.emailadres }})</span
+                  >
+                </span>
                 <input type="checkbox" v-model="record.shouldStore" />
               </label>
             </li>
@@ -258,7 +260,6 @@
 </template>
 
 <script setup lang="ts">
-import Paragraph from "@/nl-design-system/components/Paragraph.vue";
 import { onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import {


### PR DESCRIPTION
Ensures all selected search results are always checked (shouldStore = true) by default. 

Also fixes a bug where the e-mail of a selected user was not shown.