### PR TITLE
feedback #148: make more search queries / paginations switchable

### DIFF
--- a/src/features/werkbericht/WerkBerichten.vue
+++ b/src/features/werkbericht/WerkBerichten.vue
@@ -43,7 +43,6 @@ import Paragraph from "@/nl-design-system/components/Paragraph.vue";
 import Pagination from "@/nl-design-system/components/Pagination.vue";
 import { useWerkberichten } from "./service";
 import WerkBericht from "./WerkBericht.vue";
-import { ensureState } from "@/stores/create-store";
 
 const props = defineProps({
   header: {

--- a/src/features/werkbericht/WerkBerichten.vue
+++ b/src/features/werkbericht/WerkBerichten.vue
@@ -43,6 +43,7 @@ import Paragraph from "@/nl-design-system/components/Paragraph.vue";
 import Pagination from "@/nl-design-system/components/Pagination.vue";
 import { useWerkberichten } from "./service";
 import WerkBericht from "./WerkBericht.vue";
+import { ensureState } from "@/stores/create-store";
 
 const props = defineProps({
   header: {
@@ -73,13 +74,18 @@ const props = defineProps({
     type: String,
     default: "page",
   },
+  currentPage: {
+    type: Number,
+    required: true,
+  },
 });
 
-const currentPage = ref(1);
 const listEl = ref<Element>();
 
+const emit = defineEmits<{ (e: "navigate", page: number): void }>();
+
 const onNavigate = (pageNum: number) => {
-  currentPage.value = pageNum;
+  emit("navigate", pageNum);
   const list = listEl.value;
   if (list) {
     list.scrollIntoView();
@@ -90,13 +96,13 @@ const parameters = computed(() => ({
   search: props.search,
   skillIds: props.skillIds,
   typeId: props.typeId,
-  page: currentPage.value,
+  page: props.currentPage,
 }));
 
 const berichten = useWerkberichten(parameters);
 
 watch([() => props.search, () => props.skillIds, () => props.typeId], () => {
-  currentPage.value = 1;
+  emit("navigate", 1);
 });
 </script>
 

--- a/src/features/zaaksysteem/ZaakZoeker.vue
+++ b/src/features/zaaksysteem/ZaakZoeker.vue
@@ -51,8 +51,8 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, watch, computed } from "vue";
-import { useZaaksysteemService } from "./service";
+import { watch, computed } from "vue";
+import { useZakenByZaaknummer } from "./service";
 import type { Zaak } from "./types";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import Paragraph from "@/nl-design-system/components/Paragraph.vue";
@@ -83,9 +83,7 @@ const zaakSelected = (zaak: Zaak) => {
   emit("zaakSelected", zaak);
 };
 
-const service = useZaaksysteemService();
-
-const zaken = service.findByZaak(computed(() => store.value.currentSearch));
+const zaken = useZakenByZaaknummer(computed(() => store.value.currentSearch));
 
 const zoekOpZaak = () => {
   store.value.currentSearch = store.value.searchField;

--- a/src/features/zaaksysteem/ZaakZoeker.vue
+++ b/src/features/zaaksysteem/ZaakZoeker.vue
@@ -5,7 +5,7 @@
         <input
           type="search"
           placeholder="Zoek op zaaknummer"
-          v-model="store.zaakSearchParams.zaaknummer"
+          v-model="store.searchField"
           title="ZAAK-1"
         />
       </label>
@@ -14,37 +14,39 @@
       </button>
     </form>
 
-    <section class="resultaten-container" v-if="store.zaken.length > 0">
-      <div class="resultaten-heading-container">
-        <utrecht-heading class="resultaten-heading" :level="2" model-value
-          >Zoekresultaten</utrecht-heading
-        >
-
-        <div class="resultaten-found">
-          {{
-            `${store.zaken.length} ${
-              store.zaken.length > 1 ? "resultaten" : "resultaat"
-            } gevonden`
-          }}
+    <template v-if="store.currentSearch">
+      <application-message
+        v-if="zaken.error"
+        messageType="error"
+        message="Er is een probleem opgetreden."
+      ></application-message>
+      <simple-spinner v-else-if="zaken.loading"></simple-spinner>
+      <section
+        class="resultaten-container"
+        v-if="zaken.success && zaken.data.page.length > 0"
+      >
+        <div class="resultaten-heading-container">
+          <utrecht-heading class="resultaten-heading" :level="2" model-value
+            >Zoekresultaten</utrecht-heading
+          >
+          <div class="resultaten-found">
+            {{
+              `${zaken.data.page.length} ${
+                zaken.data.page.length > 1 ? "resultaten" : "resultaat"
+              } gevonden`
+            }}
+          </div>
         </div>
-      </div>
-
-      <zaken-overzicht
-        :zaken="store.zaken"
-        :vraag="contactmomentStore.huidigContactmoment?.huidigeVraag"
-        @zaak-selected="zaakSelected"
-      />
-    </section>
-
-    <application-message
-      v-if="error"
-      messageType="error"
-      message="Er is een probleem opgetreden."
-    ></application-message>
-
-    <simple-spinner v-else-if="busy"></simple-spinner>
-
-    <paragraph v-else-if="isDirty">Er zijn geen zaken gevonden.</paragraph>
+        <zaken-overzicht
+          :zaken="zaken.data.page"
+          :vraag="contactmomentStore.huidigContactmoment?.huidigeVraag"
+          @zaak-selected="zaakSelected"
+        />
+      </section>
+      <paragraph v-if="zaken.success && !zaken.data.page.length"
+        >Er zijn geen zaken gevonden.</paragraph
+      >
+    </template>
   </section>
 </template>
 
@@ -69,8 +71,8 @@ const store = ensureState({
   stateId: "zaak-zoeker",
   stateFactory() {
     return {
-      zaakSearchParams: { zaaknummer: "", bsn: "" },
-      zaken: [] as Zaak[],
+      searchField: "",
+      currentSearch: "",
     };
   },
 });
@@ -83,34 +85,14 @@ const zaakSelected = (zaak: Zaak) => {
 
 const service = useZaaksysteemService();
 
-const error = ref(false);
-const busy = ref(false);
-const isDirty = ref(false);
+const zaken = service.findByZaak(computed(() => store.value.currentSearch));
 
 const zoekOpZaak = () => {
-  busy.value = true;
-  error.value = false;
-  store.value.zaken = [];
-
-  service
-    .findByZaak(store.value.zaakSearchParams.zaaknummer)
-    .then((data) => {
-      store.value.zaken = data.page;
-      isDirty.value = true;
-    })
-    .catch((e) => {
-      error.value = true;
-      console.error(e);
-    })
-    .finally(() => {
-      busy.value = false;
-    });
+  store.value.currentSearch = store.value.searchField;
 };
 
 const singleZaak = computed(() =>
-  store.value.zaken && store.value.zaken.length === 1
-    ? store.value.zaken[0]
-    : undefined
+  zaken.success && zaken.data.page.length === 1 ? zaken.data.page[0] : undefined
 );
 
 watch(singleZaak, (n, o) => {

--- a/src/features/zaaksysteem/ZakenOverzichtKlantbeeld.vue
+++ b/src/features/zaaksysteem/ZakenOverzichtKlantbeeld.vue
@@ -41,11 +41,12 @@
 <script setup lang="ts">
 import { UtrechtHeading } from "@utrecht/web-component-library-vue";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
-import { useZaaksysteemService } from "./service";
+import { useZakenByBsn } from "./service";
 import { formatDateOnly } from "@/helpers/date";
 import type { Zaak } from "./types";
 import { useContactmomentStore } from "@/stores/contactmoment";
 import { useRouter } from "vue-router";
+import { computed } from "vue";
 
 const contactmomentStore = useContactmomentStore();
 const router = useRouter();
@@ -57,9 +58,7 @@ const props = defineProps({
   },
 });
 
-const zaakService = useZaaksysteemService();
-
-const zaken = zaakService.findByBsn(props.klantBsn).withFetcher();
+const zaken = useZakenByBsn(computed(() => props.klantBsn));
 
 const handleZaakSelected = (zaak: Zaak) => {
   if (!contactmomentStore.huidigContactmoment) return;

--- a/src/features/zaaksysteem/service.ts
+++ b/src/features/zaaksysteem/service.ts
@@ -66,12 +66,19 @@ export function useZaaksysteemService() {
 
   const zaaksysteemBaseUri = `${window.gatewayBaseUri}/api/zaken`;
 
-  const findByZaak = (zaaknummer: string) => {
-    const url = `${zaaksysteemBaseUri}?identificatie=${zaaknummer}&extend[]=all`;
-    return fetchLoggedIn(url)
-      .then(throwIfNotOk)
-      .then((x) => x.json())
-      .then((json) => parsePagination(json, parseZaak));
+  const findByZaak = (zaaknummer: Ref<string>) => {
+    const getUrl = () =>
+      !zaaknummer.value
+        ? ""
+        : `${zaaksysteemBaseUri}?identificatie=${zaaknummer.value}&extend[]=all`;
+
+    const fetcher = (url: string) =>
+      fetchLoggedIn(url)
+        .then(throwIfNotOk)
+        .then((x) => x.json())
+        .then((json) => parsePagination(json, parseZaak));
+
+    return ServiceResult.fromFetcher(getUrl, fetcher);
   };
 
   const findByBsn = (bsn: string) => {

--- a/src/features/zaaksysteem/service.ts
+++ b/src/features/zaaksysteem/service.ts
@@ -59,99 +59,82 @@ function parseZaak(zaak: any): Zaak {
   };
 }
 
-export function useZaaksysteemService() {
-  if (!window.gatewayBaseUri) {
-    console.error("gatewayBaseUri missing");
+const zaaksysteemBaseUri = `${window.gatewayBaseUri}/api/zaken`;
+
+export const useZakenByBsn = (bsn: Ref<string>) => {
+  const getUrl = () => {
+    if (!bsn.value) return "";
+    return `${zaaksysteemBaseUri}?rollen.betrokkeneIdentificatie.inpBsn=${bsn.value}&extend[]=zaaktype&extend[]=status&extend[]=rollen`;
+  };
+
+  const fetcher = (url: string): Promise<Paginated<Zaak>> =>
+    fetchLoggedIn(url)
+      .then(throwIfNotOk)
+      .then((x) => x.json())
+      .then((json) => parsePagination(json, parseZaak));
+
+  return ServiceResult.fromFetcher(getUrl, fetcher);
+};
+
+export const useZakenByZaaknummer = (zaaknummer: Ref<string>) => {
+  const getUrl = () =>
+    !zaaknummer.value
+      ? ""
+      : `${zaaksysteemBaseUri}?identificatie=${zaaknummer.value}&extend[]=all`;
+
+  const fetcher = (url: string) =>
+    fetchLoggedIn(url)
+      .then(throwIfNotOk)
+      .then((x) => x.json())
+      .then((json) => parsePagination(json, parseZaak));
+
+  return ServiceResult.fromFetcher(getUrl, fetcher);
+};
+
+export const useZaakById = (id: Ref<string>): ServiceData<ZaakDetails> => {
+  const getUrl = () =>
+    !id.value
+      ? ""
+      : `${zaaksysteemBaseUri}/${id.value}?extend[]=all&extend[]=x-commongateway-metadata.self`;
+
+  function fetcher(url: string): Promise<ZaakDetails> {
+    return fetchLoggedIn(url)
+      .then(throwIfNotOk)
+      .then((x) => x.json())
+      .then((zaak) => {
+        const fataleDatum = DateTime.fromJSDate(new Date(zaak.startdatum))
+          .plus({
+            days: parseInt(zaak.embedded.zaaktype.doorlooptijd, 10),
+          })
+          .toJSDate();
+        const streefDatum = DateTime.fromJSDate(new Date(zaak.startdatum))
+          .plus({
+            days: parseInt(zaak.embedded.zaaktype.servicenorm, 10),
+          })
+          .toJSDate();
+
+        return {
+          ...zaak,
+          zaaktype: zaak.embedded.zaaktype.id,
+          zaaktypeLabel: zaak.embedded.zaaktype.onderwerp,
+          zaaktypeOmschrijving: zaak.embedded.zaaktype.omschrijving,
+          status: zaak.embedded.status.statustoelichting,
+          behandelaar: getNamePerRoltype(zaak, "behandelaar"),
+          aanvrager: getNamePerRoltype(zaak, "initiator"),
+          startdatum: zaak.startdatum,
+          fataleDatum: fataleDatum,
+          streefDatum: streefDatum,
+          indienDatum: zaak.publicatiedatum ?? "Onbekend",
+          registratieDatum: new Date(zaak.registratiedatum),
+          self: zaak["x-commongateway-metadata"].self,
+          documenten: mapDocumenten(zaak?.embedded?.zaakinformatieobjecten),
+          omschrijving: zaak.omschrijving,
+        } as ZaakDetails;
+      });
   }
 
-  const zaaksysteemBaseUri = `${window.gatewayBaseUri}/api/zaken`;
-
-  const findByZaak = (zaaknummer: Ref<string>) => {
-    const getUrl = () =>
-      !zaaknummer.value
-        ? ""
-        : `${zaaksysteemBaseUri}?identificatie=${zaaknummer.value}&extend[]=all`;
-
-    const fetcher = (url: string) =>
-      fetchLoggedIn(url)
-        .then(throwIfNotOk)
-        .then((x) => x.json())
-        .then((json) => parsePagination(json, parseZaak));
-
-    return ServiceResult.fromFetcher(getUrl, fetcher);
-  };
-
-  const findByBsn = (bsn: string) => {
-    const getFindByBsnURL = () => {
-      if (!bsn) return "";
-
-      return `${zaaksysteemBaseUri}?rollen.betrokkeneIdentificatie.inpBsn=${bsn}&extend[]=zaaktype&extend[]=status&extend[]=rollen`;
-    };
-
-    const getZaakByBsn = (url: string): Promise<Paginated<Zaak>> =>
-      fetchLoggedIn(url)
-        .then(throwIfNotOk)
-        .then((x) => x.json())
-        .then((json) => parsePagination(json, parseZaak));
-
-    const withoutFetcher = () => getZaakByBsn(getFindByBsnURL());
-
-    const withFetcher = () =>
-      ServiceResult.fromFetcher(getFindByBsnURL, getZaakByBsn);
-
-    return { withoutFetcher, withFetcher };
-  };
-
-  const getZaak = (id: Ref<string>): ServiceData<ZaakDetails> => {
-    function get(url: string): Promise<ZaakDetails> {
-      return fetchLoggedIn(url)
-        .then(throwIfNotOk)
-        .then((x) => x.json())
-        .then((zaak) => {
-          const fataleDatum = DateTime.fromJSDate(new Date(zaak.startdatum))
-            .plus({
-              days: parseInt(zaak.embedded.zaaktype.doorlooptijd, 10),
-            })
-            .toJSDate();
-          const streefDatum = DateTime.fromJSDate(new Date(zaak.startdatum))
-            .plus({
-              days: parseInt(zaak.embedded.zaaktype.servicenorm, 10),
-            })
-            .toJSDate();
-
-          return {
-            ...zaak,
-            zaaktype: zaak.embedded.zaaktype.id,
-            zaaktypeLabel: zaak.embedded.zaaktype.onderwerp,
-            zaaktypeOmschrijving: zaak.embedded.zaaktype.omschrijving,
-            status: zaak.embedded.status.statustoelichting,
-            behandelaar: getNamePerRoltype(zaak, "behandelaar"),
-            aanvrager: getNamePerRoltype(zaak, "initiator"),
-            startdatum: zaak.startdatum,
-            fataleDatum: fataleDatum,
-            streefDatum: streefDatum,
-            indienDatum: zaak.publicatiedatum ?? "Onbekend",
-            registratieDatum: new Date(zaak.registratiedatum),
-            self: zaak["x-commongateway-metadata"].self,
-            documenten: mapDocumenten(zaak?.embedded?.zaakinformatieobjecten),
-            omschrijving: zaak.omschrijving,
-          } as ZaakDetails;
-        });
-    }
-
-    return ServiceResult.fromFetcher(
-      () =>
-        `${zaaksysteemBaseUri}/${id.value}?extend[]=all&extend[]=x-commongateway-metadata.self`,
-      get
-    );
-  };
-
-  return {
-    findByZaak,
-    findByBsn,
-    getZaak,
-  };
-}
+  return ServiceResult.fromFetcher(getUrl, fetcher);
+};
 
 export async function updateToelichting(
   zaak: ZaakDetails,

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -24,8 +24,12 @@
             v-if="berichtTypes.state === 'success'"
           >
             Naar welk type bericht ben je op zoek?
-            <select name="type" id="werkberichtTypeInput">
-              <option value="">Alle</option>
+            <select
+              name="type"
+              id="werkberichtTypeInput"
+              v-model="state.typeIdField"
+            >
+              <option :value="undefined">Alle</option>
               <option
                 v-for="[key, label] in berichtTypes.data.entries"
                 :key="`berichtTypes_${key}`"
@@ -43,6 +47,7 @@
               id="searchInput"
               placeholder="Zoek een werkinstructie of nieuwsbericht"
               @search="handleSearch"
+              v-model="state.searchField"
           /></label>
           <button title="Zoeken">
             <span>Zoeken</span><utrecht-icon-loupe model-value />
@@ -82,12 +87,14 @@
       </li>
     </menu>
     <werk-berichten
-      v-if="currentSearch"
+      v-if="state.currentSearch"
       :level="2"
       page-param-name="werkberichtsearchpage"
-      :search="currentSearch"
+      :search="state.currentSearch"
       :skill-ids="userStore.preferences.skills"
-      :type-id="currentTypeId"
+      :type-id="state.currentTypeId"
+      :current-page="state.searchPage"
+      @navigate="state.searchPage = $event"
       header="Zoekresultaten"
     />
     <template v-else>
@@ -98,6 +105,8 @@
         page-param-name="nieuwspage"
         :typeId="nieuwsId"
         :skill-ids="userStore.preferences.skills"
+        :current-page="state.nieuwsPage"
+        @navigate="state.nieuwsPage = $event"
       />
       <werk-berichten
         :level="2"
@@ -106,6 +115,8 @@
         page-param-name="werkinstructiepage"
         :typeId="werkInstructieId"
         :skill-ids="userStore.preferences.skills"
+        :current-page="state.werkinstructiesPage"
+        @navigate="state.werkinstructiesPage = $event"
       />
     </template>
   </div>
@@ -125,14 +136,27 @@ import {
 import { parseValidInt } from "@/services";
 import MultiSelect from "@/components/MultiSelect.vue";
 import { useUserStore } from "@/stores/user";
+import { ensureState } from "@/stores/create-store";
 
 const { pubBeheerUrl } = window;
 
 const werkinstructie = "werkinstructie";
 const nieuws = "nieuws";
 
-const currentSearch = ref("");
-const currentTypeId = ref<number>();
+const state = ensureState({
+  stateId: "HomeView",
+  stateFactory() {
+    return {
+      searchField: "",
+      typeIdField: undefined as number | undefined,
+      currentSearch: "",
+      currentTypeId: undefined as number | undefined,
+      searchPage: 1,
+      nieuwsPage: 1,
+      werkinstructiesPage: 1,
+    };
+  },
+});
 
 const userStore = useUserStore();
 
@@ -167,15 +191,15 @@ function handleSubmit(e: Event) {
   e.preventDefault();
   const formData = new FormData(currentTarget);
   const obj = Object.fromEntries(formData);
-  currentSearch.value = obj?.search?.toString() || "";
-  currentTypeId.value = parseValidInt(obj?.type?.toString());
+  state.value.currentSearch = obj?.search?.toString() || "";
+  state.value.currentTypeId = parseValidInt(obj?.type?.toString());
 }
 
 function handleSearch(e: Event) {
   const { currentTarget } = e;
   if (!(currentTarget instanceof HTMLInputElement)) return;
   e.preventDefault();
-  currentSearch.value = currentTarget.value;
+  state.value.currentSearch = currentTarget.value;
 }
 </script>
 

--- a/src/views/ZaakDetailView.vue
+++ b/src/views/ZaakDetailView.vue
@@ -13,17 +13,15 @@
 </template>
 
 <script setup lang="ts">
-import { useZaaksysteemService } from "@/features/zaaksysteem/service";
-import ApplicationMessage from "../components/ApplicationMessage.vue";
-import ZaakDetails from "../features/zaaksysteem/ZaakDetails.vue";
+import { useZaakById } from "@/features/zaaksysteem/service";
+import ApplicationMessage from "@/components/ApplicationMessage.vue";
+import ZaakDetails from "@/features/zaaksysteem/ZaakDetails.vue";
 import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import { computed } from "vue";
 
 const props = defineProps<{ zaakId: string }>();
 
-const zaaksysteemService = useZaaksysteemService();
-
-const zaak = zaaksysteemService.getZaak(computed(() => props.zaakId));
+const zaak = useZaakById(computed(() => props.zaakId));
 </script>
 
 <style scoped lang="scss"></style>


### PR DESCRIPTION
1. Use `ensureState` to keep state when switching contactmomenten for the following search functions:
- GlobalSearch
- Werkberichten
- Zaken
2. Refactor `findByZaak` to use the same conventions as the other search functions