### PR TITLE
REFACTOR koppelKlant to contactverzoek check shouldStore

### DIFF
--- a/src/views/AfhandelingView.vue
+++ b/src/views/AfhandelingView.vue
@@ -567,12 +567,7 @@ const saveVraag = async (vraag: Vraag, gespreksId?: string) => {
       afwijkendOnderwerp: vraag.afwijkendOnderwerp || undefined,
     });
 
-    const selectedKlant = vraag.klanten.findIndex((klant) => klant.shouldStore);
-
-    koppelKlant({
-      klantId: vraag.klanten[selectedKlant].klant.id,
-      contactmomentId: contactverzoek.id,
-    });
+    koppelKlanten(vraag, contactverzoek.id);
   }
 
   return saveContactmoment(contactmoment).then((savedContactmoment) => {

--- a/src/views/AfhandelingView.vue
+++ b/src/views/AfhandelingView.vue
@@ -567,8 +567,10 @@ const saveVraag = async (vraag: Vraag, gespreksId?: string) => {
       afwijkendOnderwerp: vraag.afwijkendOnderwerp || undefined,
     });
 
+    const selectedKlant = vraag.klanten.findIndex((klant) => klant.shouldStore);
+
     koppelKlant({
-      klantId: vraag.klanten[0].klant.id,
+      klantId: vraag.klanten[selectedKlant].klant.id,
       contactmomentId: contactverzoek.id,
     });
   }


### PR DESCRIPTION
We always took the first of `klanten` array, instead of actually checking _which_ klant had to be coupled. 