### PR TITLE
REFACTOR all int_compare and bool_compare implementations

### DIFF
--- a/src/features/klant/bedrijf/service.ts
+++ b/src/features/klant/bedrijf/service.ts
@@ -23,7 +23,7 @@ const handelsRegisterBaseUrl = window.gatewayBaseUri + "/api/vestigingen";
 const bedrijfQueryDictionary: BedrijfQueryDictionary = {
   postcodeHuisnummer: ({ postcode, huisnummer }) => [
     ["bezoekadres.postcode", postcode.numbers + postcode.digits],
-    ["bezoekadres.huisnummer", huisnummer],
+    ["bezoekadres.huisnummer[int_compare]", huisnummer],
   ],
   emailadres: (search) => [["emailAdres", `%${search}%`]],
   telefoonnummer: (search) => [["telefoonnummer", `%${search}%`]],

--- a/src/features/klant/persoon/service.ts
+++ b/src/features/klant/persoon/service.ts
@@ -48,7 +48,7 @@ const queryDictionary: PersoonQueryParams = {
   postcodeHuisnummer: ({ postcode, huisnummer }) => [
     ["verblijfplaats.postcode", `${postcode.numbers}${postcode.digits}`],
 
-    ["verblijfplaats.huisnummer", huisnummer],
+    ["verblijfplaats.huisnummer[int_compare]", huisnummer],
   ],
 };
 

--- a/src/features/werkbericht/service.ts
+++ b/src/features/werkbericht/service.ts
@@ -169,7 +169,7 @@ export function useWerkberichten(
     params.push(["acf.publicationEndDate[after]", "now"]);
 
     if (typeId) {
-      params.push(["acf.publicationType", typeId.toString()]);
+      params.push(["acf.publicationType[int_compare]", typeId.toString()]);
     }
 
     if (search) {
@@ -182,7 +182,10 @@ export function useWerkberichten(
 
     if (skillIds?.length) {
       skillIds.forEach((skillId) => {
-        params.push(["acf.publicationSkill[]", skillId.toString()]);
+        params.push([
+          "acf.publicationSkill[int_compare][]",
+          skillId.toString(),
+        ]);
       });
     }
     return `${BERICHTEN_BASE_URI}?${new URLSearchParams(params)}`;
@@ -247,7 +250,7 @@ export function useFeaturedWerkberichtenCount() {
 
   function getUrl() {
     const params: [string, string][] = [
-      ["acf.publicationFeatured", "true"],
+      ["acf.publicationFeatured[bool_compare]", "true"],
       ["fields[]", "x-commongateway-metadata.dateRead"],
       ["extend[]", "x-commongateway-metadata.dateRead"],
       ["acf.publicationEndDate[after]", "now"],


### PR DESCRIPTION
These changes are required for filtering on properties that are type `boolean` or `string` within the gateway.

Note: changes are **not** required for stringed values (e.g. "true" or "123"). 