### PR TITLE
REFACTOR klant.id to klant._self.id

### DIFF
--- a/src/features/contactmoment/service.ts
+++ b/src/features/contactmoment/service.ts
@@ -98,7 +98,7 @@ export function useContactverzoekenByKlantId(
     url.searchParams.append("extend[]", "contactmoment.todo");
     url.searchParams.set("_limit", "10");
     url.searchParams.set("_page", page.value.toString());
-    url.searchParams.set("klant.id", id.value);
+    url.searchParams.set("klant._self.id", id.value);
     url.searchParams.set("contactmoment.todo", "IS NOT NULL");
     return url.toString();
   }

--- a/src/features/shared/get-contactmomenten-service.ts
+++ b/src/features/shared/get-contactmomenten-service.ts
@@ -116,7 +116,7 @@ export function useContactmomentenByKlantId(
     url.searchParams.append("extend[]", "contactmoment.todo");
     url.searchParams.set("_limit", "10");
     url.searchParams.set("_page", page.value.toString());
-    url.searchParams.set("klant.id", id.value);
+    url.searchParams.set("klant._self.id", id.value);
     url.searchParams.set("contactmoment.todo", "IS NULL");
     return url.toString();
   }


### PR DESCRIPTION
Fixes the retrieval of contactmomenten (and todos) in the klant detail page. 