### PR TITLE
REFACTOR search to _search[properties]

### DIFF
--- a/src/features/werkbericht/service.ts
+++ b/src/features/werkbericht/service.ts
@@ -171,7 +171,7 @@ export function useWerkberichten(
     }
 
     if (search) {
-      params.push(["search", search]);
+      params.push(["_search[title.rendered,acf.publicationContent]", search]);
     }
 
     if (page) {


### PR DESCRIPTION
Fixes the search through publications to only check title and content. 

Waiting on backend to update as well.