### PR TITLE
REFACTOR wildcard queries (%) to like operators [like]

### DIFF
--- a/src/features/klant/bedrijf/service.ts
+++ b/src/features/klant/bedrijf/service.ts
@@ -25,10 +25,10 @@ const bedrijfQueryDictionary: BedrijfQueryDictionary = {
     ["embedded.bezoekadres.postcode", postcode.numbers + postcode.digits],
     ["embedded.bezoekadres.huisnummer[int_compare]", huisnummer],
   ],
-  emailadres: (search) => [["emailAdres", `%${search}%`]],
-  telefoonnummer: (search) => [["telefoonnummer", `%${search}%`]],
+  emailadres: (search) => [["emailAdres[like]", search]],
+  telefoonnummer: (search) => [["telefoonnummer[like]", search]],
   kvkNummer: (search) => [["kvknummer", search]],
-  handelsnaam: (search) => [["eersteHandelsnaam", `%${search}%`]],
+  handelsnaam: (search) => [["eersteHandelsnaam[like]", search]],
 };
 
 const getSearchBedrijvenUrl = <K extends SearchCategories>({

--- a/src/features/klant/service.ts
+++ b/src/features/klant/service.ts
@@ -37,9 +37,9 @@ type QueryDictionary = {
 };
 
 const queryDictionary: QueryDictionary = {
-  email: (search) => [["embedded.emails.email", `%${search}%`]],
+  email: (search) => [["embedded.emails.email[like]", search]],
   telefoonnummer: (search) => [
-    ["telefoonnummers.telefoonnummer", `%${search}%`],
+    ["embedded.telefoonnummers.telefoonnummer[like]", search],
   ],
 };
 


### PR DESCRIPTION
Change was required due to change in the gateway, wildcard searches are now done via like operators and no longer via wildcard percentage queries. 