### PR TITLE
PC-686-scenario-31-32-33-34-35

### DIFF
--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
@@ -65,8 +65,21 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
 
             if (!string.IsNullOrEmpty(request.Skill))
             {
-                var skillCheckbox = page.GetByRole(AriaRole.Checkbox, new() { Name = request.Skill });
-                await skillCheckbox.CheckAsync(); // Ensure the skill checkbox is checked
+                List<string> skills = new();
+
+                if (request.Skill.Contains(","))
+                    skills.AddRange(request.Skill.Split(","));
+                else
+                        skills.Add(request.Skill);
+                
+
+
+                    foreach (var skill in skills)
+                    {
+                        var skillCheckbox = page.GetByRole(AriaRole.Checkbox, new() { Name = skill });
+                        await skillCheckbox.CheckAsync(); // Ensure the skill checkbox is checked
+                    }
+                 
             }
 
             // Use the current time as the base publish date
@@ -82,6 +95,9 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
             var publishDateInput = page.GetByLabel("Publicatiedatum");
             await publishDateInput.FillAsync(publishDate.ToString("yyyy-MM-ddTHH:mm"));
 
+            var PublicatieEinddatumInput = page.GetByLabel("Publicatie-einddatum");
+            await PublicatieEinddatumInput.FillAsync(request.PublicatieEinddatum.ToString("yyyy-MM-ddTHH:mm"));
+
             var opslaanKnop = page.GetByRole(AriaRole.Button, new() { Name = "Opslaan" });
             while (await opslaanKnop.IsVisibleAsync() && await opslaanKnop.IsEnabledAsync())
             {
@@ -95,7 +111,7 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
                 Title = request.Title,
                 PublishDateOffset = request.PublishDateOffset,
                 PublicatieDatum = publishDate,
-                PublicatieEinddatum = publishDate.AddYears(1),
+                PublicatieEinddatum = request.PublicatieEinddatum,
                 Skill = request.Skill,
                 Body = request.Body,
                 BerichtType = request.BerichtType,
@@ -128,8 +144,6 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
     internal record class Bericht(IPage Page) : CreateBerichtRequest, IAsyncDisposable
     {
         public required new string Body { get; init; }
-        public DateTime PublicatieDatum { get; init; }
-        public DateTime PublicatieEinddatum { get; init; }
         public async ValueTask DisposeAsync()
         {
             await Page.Context.Tracing.GroupEndAsync();
@@ -169,5 +183,8 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
         public BerichtType BerichtType { get; init; } = BerichtType.Nieuws;
 
         public TimeSpan? PublishDateOffset { get; init; }
+
+        public DateTime PublicatieDatum { get; init; }
+        public DateTime PublicatieEinddatum { get; init; } = DateTime.Now.AddDays(1);
     }
 }

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
@@ -70,11 +70,9 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
                 if (request.Skill.Contains(","))
                     skills.AddRange(request.Skill.Split(","));
                 else
-                        skills.Add(request.Skill);
-                
+                        skills.Add(request.Skill);            
 
-
-                    foreach (var skill in skills)
+                     foreach (var skill in skills)
                     {
                         var skillCheckbox = page.GetByRole(AriaRole.Checkbox, new() { Name = skill });
                         await skillCheckbox.CheckAsync(); // Ensure the skill checkbox is checked

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/Helpers/CreateBericht.cs
@@ -70,14 +70,13 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
                 if (request.Skill.Contains(","))
                     skills.AddRange(request.Skill.Split(","));
                 else
-                        skills.Add(request.Skill);            
+                    skills.Add(request.Skill);
 
-                     foreach (var skill in skills)
-                    {
-                        var skillCheckbox = page.GetByRole(AriaRole.Checkbox, new() { Name = skill });
-                        await skillCheckbox.CheckAsync(); // Ensure the skill checkbox is checked
-                    }
-                 
+                foreach (var skill in skills)
+                {
+                    var skillCheckbox = page.GetByRole(AriaRole.Checkbox, new() { Name = skill });
+                    await skillCheckbox.CheckAsync(); // Ensure the skill checkbox is checked
+                }
             }
 
             // Use the current time as the base publish date
@@ -115,12 +114,12 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
                 BerichtType = request.BerichtType,
             };
         }
+
         public static async Task<Bericht> OnSaveBericht(this IPage page)
         {
-            
-          var title=  await page.GetByRole(AriaRole.Textbox, new() { Name = "Titel" }).TextContentAsync() ?? string.Empty;
-          var body = await page.GetByRole(AriaRole.Textbox, new() { Name = "Rich Text Editor" }).TextContentAsync() ?? string.Empty;
-          var berichtType = await page.GetByRole(AriaRole.Radio, new() { Name = BerichtType.Nieuws.ToString() }).IsCheckedAsync() ? BerichtType.Nieuws : BerichtType.Werkinstructie;
+            var title = await page.GetByRole(AriaRole.Textbox, new() { Name = "Titel" }).TextContentAsync() ?? string.Empty;
+            var body = await page.GetByRole(AriaRole.Textbox, new() { Name = "Rich Text Editor" }).TextContentAsync() ?? string.Empty;
+            var berichtType = await page.GetByRole(AriaRole.Radio, new() { Name = BerichtType.Nieuws.ToString() }).IsCheckedAsync() ? BerichtType.Nieuws : BerichtType.Werkinstructie;
 
             var opslaanKnop = page.GetByRole(AriaRole.Button, new() { Name = "Opslaan" });
             while (await opslaanKnop.IsVisibleAsync() && await opslaanKnop.IsEnabledAsync())
@@ -130,13 +129,12 @@ namespace Kiss.Bff.EndToEndTest.NieuwsEnWerkInstructies.Helpers
 
             await page.GetByRole(AriaRole.Table).WaitForAsync();
             return new(page)
-            { 
+            {
                 Title = title,
                 Body = body,
                 BerichtType = berichtType
             };
         }
-
     }
 
     internal record class Bericht(IPage Page) : CreateBerichtRequest, IAsyncDisposable

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
@@ -882,23 +882,12 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
         await Step("When the user navigates to the HOME Page And the user browses through all pages of the Nieuws section");
 
         await Page.GotoAsync("/");
-
-
-        var nextPageButton = Page.GetNieuwsSection().GetNextPageLink();
-        var nieuwsSection = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter();
-
-        bool niewsExists = false;
-        while (!await nextPageButton.IsDisabledPageLink())
-        {
-            await nextPageButton.ClickAsync();
-            niewsExists = await nieuwsSection.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title }).IsVisibleAsync();
-
-            await nieuwsSection.First.WaitForAsync();
-        }
+ 
 
         await Step("Then the nieuwsbericht should be visible");
 
-        Assert.AreEqual<bool>(niewsExists, true);
+        Assert.AreEqual(true, await Page.IsBerichtVisibleOnAllPagesAsync(nieuws));
+
 
     }
 
@@ -913,22 +902,10 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Page.GotoAsync("/");
 
-        await Step("And browses through all pages of the Nieuws section");
-        
-        var nextPageButton = Page.GetNieuwsSection().GetNextPageLink();
-        var nieuwsSection = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter();
+        await Step("And browses through all pages of the Nieuws section and Then the nieuwsbericht should not be visible");
 
-        bool niewsExists = false;
-        while (!await nextPageButton.IsDisabledPageLink())
-        {
-            await nextPageButton.ClickAsync();
-            niewsExists = await nieuwsSection.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title }).IsVisibleAsync();
-
-            await nieuwsSection.First.WaitForAsync();
-        }
-        await Step("Then the nieuwsbericht should not be visible");
-
-        Assert.AreEqual<bool>(niewsExists, false);
+        Assert.AreEqual(false, await Page.IsBerichtVisibleOnAllPagesAsync(nieuws)); 
+         
     }
 
     [TestMethod]
@@ -942,22 +919,9 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Page.GotoAsync("/");
 
-        await Step("And browses through all pages of the Nieuws section");
+        await Step("And browses through all pages of the Nieuws section and Then the nieuwsbericht should be visible");
 
-         var nextPageButton = Page.GetNieuwsSection().GetNextPageLink();
-        var nieuwsSection = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter();
-
-        bool niewsExists = false;
-        while (!await nextPageButton.IsDisabledPageLink())
-        {
-            await nextPageButton.ClickAsync();
-            niewsExists = await nieuwsSection.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title }).IsVisibleAsync();
-
-            await nieuwsSection.First.WaitForAsync();
-        }
-        await Step("Then the nieuwsbericht should be visible");
-
-        Assert.AreEqual<bool>(niewsExists, true);
+        Assert.AreEqual(true, await Page.IsBerichtVisibleOnAllPagesAsync(nieuws)); 
 
     }
 
@@ -978,20 +942,13 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Step("And browses through all pages of the Nieuws section");
 
-        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter(new()
-        {
-            Has = Page.GetByRole(AriaRole.Heading, new() { Name = niewus.Title }).First
-        });
-       
+         var article = await Page.GetBerichtOnAllPagesAsync(niewus);
+
         await Step("Then the nieuwsbericht should be displayed with the corresponding skills as labels");
        
-        await Expect(articles).ToBeVisibleAsync();
+        await Expect(article).ToBeVisibleAsync();
 
-        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(3);       
-        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill1.Naam }) })).ToBeVisibleAsync();
-        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill2.Naam }) })).ToBeVisibleAsync();
-        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill3.Naam }) })).ToBeVisibleAsync();
-
+        Assert.AreEqual(true, await Page.AreSkillsVisibleByNameAsync(article,new() { skill1.Naam, skill2.Naam, skill3.Naam }));
     }
 
     [TestMethod]
@@ -1010,18 +967,13 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Step("And browses through all pages of the Nieuws section");
 
-        var articles = Page.GetWerkinstructiesSection().GetByRole(AriaRole.Article).Filter(new()
-        {
-            Has = Page.GetByRole(AriaRole.Heading, new() { Name = werkinstructie.Title }).First
-        });
+        var article = await Page.GetBerichtOnAllPagesAsync(werkinstructie);
 
         await Step("Then the werkinstructie should be displayed with the corresponding skills as labels");
 
-        await Expect(articles).ToBeVisibleAsync();
+        await Expect(article).ToBeVisibleAsync();
 
-        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(2);
-        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill1.Naam }) })).ToBeVisibleAsync();
-        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill2.Naam }) })).ToBeVisibleAsync();
+        Assert.AreEqual(true, await Page.AreSkillsVisibleByNameAsync(article,new() { skill1.Naam, skill2.Naam }));
 
 
     }

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
@@ -882,7 +882,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatiedatum in the past");
 
-        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublishDateOffset = TimeSpan.FromDays(-1) });
+        await using var nieuws = await Page.CreateBerichtAsync(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublishDateOffset = TimeSpan.FromDays(-1) });
 
         await Step("When the user navigates to the HOME Page And the user browses through all pages of the Nieuws section");
 
@@ -901,7 +901,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatie-einddatum in the past");
 
-        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(-1) });
+        await using var nieuws = await Page.CreateBerichtAsync(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(-1) });
 
         await Step("When the user navigates to the HOME Page");
 
@@ -923,7 +923,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatie-einddatum in the future");
 
-        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(1) });
+        await using var nieuws = await Page.CreateBerichtAsync(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(1) });
 
         await Step("When the user navigates to the HOME Page");
 
@@ -949,7 +949,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
         await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
         await using var skill3 = await Page.CreateSkill(Guid.NewGuid().ToString());
 
-        await using var niewus = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, Skill = $"{skill1.Naam},{skill2.Naam},{skill3.Naam}" });
+        await using var niewus = await Page.CreateBerichtAsync(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, Skill = $"{skill1.Naam},{skill2.Naam},{skill3.Naam}" });
 
         await Step("When the user navigates to the HOME Page");
 
@@ -981,7 +981,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
         await using var skill1 = await Page.CreateSkill(Guid.NewGuid().ToString());
         await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
 
-        await using var werkinstructie = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Werkinstructie, Skill = $"{skill1.Naam},{skill2.Naam}" });
+        await using var werkinstructie = await Page.CreateBerichtAsync(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Werkinstructie, Skill = $"{skill1.Naam},{skill2.Naam}" });
 
         await Step("When the user navigates to the HOME Page");
 

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
@@ -976,11 +976,18 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatiedatum in the past");
 
-        await Step("When the user navigates to the HOME PageAnd the user browses through all pages of the Nieuws section");
+        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublishDateOffset = TimeSpan.FromDays(-1) });
+
+        await Step("When the user navigates to the HOME Page And the user browses through all pages of the Nieuws section");
+
+        await Page.GotoAsync("/");
+        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
 
         await Step("Then the nieuwsbericht should be visible");
 
-        Assert.Inconclusive("Not implemented yet");
+        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title })).ToBeVisibleAsync();
+
+
     }
 
     [TestMethod]
@@ -988,13 +995,22 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatie-einddatum in the past");
 
+        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(-1) });
+
         await Step("When the user navigates to the HOME Page");
+
+        await Page.GotoAsync("/");
+
 
         await Step("And browses through all pages of the Nieuws section");
 
+        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
+
+
         await Step("Then the nieuwsbericht should not be visible");
 
-        Assert.Inconclusive("Not implemented yet");
+        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title })).ToBeHiddenAsync();
+
     }
 
     [TestMethod]
@@ -1002,13 +1018,21 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht for a publicatie-einddatum in the future");
 
+        await using var nieuws = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, PublicatieEinddatum = DateTime.Now.AddDays(1) });
+
         await Step("When the user navigates to the HOME Page");
+
+        await Page.GotoAsync("/");
 
         await Step("And browses through all pages of the Nieuws section");
 
+        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
+
         await Step("Then the nieuwsbericht should be visible");
 
-        Assert.Inconclusive("Not implemented yet");
+        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title })).ToBeHiddenAsync();
+
+
     }
 
     [TestMethod]
@@ -1016,13 +1040,28 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a nieuwsbericht with multiple skills");
 
+        await using var skill1 = await Page.CreateSkill(Guid.NewGuid().ToString());
+        await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
+        await using var skill3 = await Page.CreateSkill(Guid.NewGuid().ToString());
+
+        await using var bericht = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, Skill = $"{skill1.Naam},{skill2.Naam},{skill3.Naam}" });
+
         await Step("When the user navigates to the HOME Page");
+
+        await Page.GotoAsync("/");
 
         await Step("And browses through all pages of the Nieuws section");
 
+        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter(new()
+        {
+            Has = Page.GetByRole(AriaRole.Heading, new() { Name = bericht.Title }).First
+        });
+       
         await Step("Then the nieuwsbericht should be displayed with the corresponding skills as labels");
+       
+        await Expect(articles).ToBeVisibleAsync();
+        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(3);
 
-        Assert.Inconclusive("Not implemented yet");
     }
 
     [TestMethod]
@@ -1030,12 +1069,22 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
     {
         await Step("Given a werkinstructie with multiple skills");
 
+        await using var skill1 = await Page.CreateSkill(Guid.NewGuid().ToString());
+        await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
+
+        await using var bericht = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Werkinstructie, Skill = $"{skill1.Naam},{skill2.Naam}" });
+
         await Step("When the user navigates to the HOME Page");
+
+        await Page.GotoAsync("/");
 
         await Step("And browses through all pages of the Nieuws section");
 
+        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
+         
         await Step("Then the werkinstructie should be displayed with the corresponding skills as labels");
 
-        Assert.Inconclusive("Not implemented yet");
+        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = bericht.Title })).ToBeVisibleAsync();
+        
     }
 }

--- a/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/NieuwsEnWerkInstructies/NieuwsEnWerkInstructiesScenarios.cs
@@ -824,7 +824,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Step("When the user clicks on the “Toevoegen” button");
 
-        await Page.GetByRole(AriaRole.Link, new() { Name = "Toevoegen" }).ClickAsync();
+        await Page.GetByRole(AriaRole.Link , new() { Name = "Toevoegen" }).ClickAsync();
 
         await Step("And selects ‘Nieuws’  as ‘Type’");
 
@@ -1001,7 +1001,6 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Page.GotoAsync("/");
 
-
         await Step("And browses through all pages of the Nieuws section");
 
         var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
@@ -1030,7 +1029,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Step("Then the nieuwsbericht should be visible");
 
-        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title })).ToBeHiddenAsync();
+        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = nieuws.Title })).ToBeVisibleAsync();
 
 
     }
@@ -1044,7 +1043,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
         await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
         await using var skill3 = await Page.CreateSkill(Guid.NewGuid().ToString());
 
-        await using var bericht = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, Skill = $"{skill1.Naam},{skill2.Naam},{skill3.Naam}" });
+        await using var niewus = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Nieuws, Skill = $"{skill1.Naam},{skill2.Naam},{skill3.Naam}" });
 
         await Step("When the user navigates to the HOME Page");
 
@@ -1054,13 +1053,17 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article).Filter(new()
         {
-            Has = Page.GetByRole(AriaRole.Heading, new() { Name = bericht.Title }).First
+            Has = Page.GetByRole(AriaRole.Heading, new() { Name = niewus.Title }).First
         });
        
         await Step("Then the nieuwsbericht should be displayed with the corresponding skills as labels");
        
         await Expect(articles).ToBeVisibleAsync();
-        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(3);
+
+        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(3);       
+        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill1.Naam }) })).ToBeVisibleAsync();
+        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill2.Naam }) })).ToBeVisibleAsync();
+        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill3.Naam }) })).ToBeVisibleAsync();
 
     }
 
@@ -1072,7 +1075,7 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
         await using var skill1 = await Page.CreateSkill(Guid.NewGuid().ToString());
         await using var skill2 = await Page.CreateSkill(Guid.NewGuid().ToString());
 
-        await using var bericht = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Werkinstructie, Skill = $"{skill1.Naam},{skill2.Naam}" });
+        await using var werkinstructie = await Page.CreateBericht(new() { Title = Guid.NewGuid().ToString(), BerichtType = BerichtType.Werkinstructie, Skill = $"{skill1.Naam},{skill2.Naam}" });
 
         await Step("When the user navigates to the HOME Page");
 
@@ -1080,11 +1083,19 @@ public class NieuwsEnWerkInstructiesScenarios : KissPlaywrightTest
 
         await Step("And browses through all pages of the Nieuws section");
 
-        var articles = Page.GetNieuwsSection().GetByRole(AriaRole.Article);
-         
+        var articles = Page.GetWerkinstructiesSection().GetByRole(AriaRole.Article).Filter(new()
+        {
+            Has = Page.GetByRole(AriaRole.Heading, new() { Name = werkinstructie.Title }).First
+        });
+
         await Step("Then the werkinstructie should be displayed with the corresponding skills as labels");
 
-        await Expect(articles.GetByRole(AriaRole.Heading, new() { Name = bericht.Title })).ToBeVisibleAsync();
-        
+        await Expect(articles).ToBeVisibleAsync();
+
+        await Expect(articles.Locator(".skills-container").Locator("small")).ToHaveCountAsync(2);
+        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill1.Naam }) })).ToBeVisibleAsync();
+        await Expect(articles.Filter(new() { Has = Page.Locator("small", new() { HasText = skill2.Naam }) })).ToBeVisibleAsync();
+
+
     }
 }


### PR DESCRIPTION
- Add support for handling multiple skills in `CreateBericht.cs`
- Set `PublicatieEinddatum` from request in `CreateBericht.cs`
- Update `Bericht` record class with new date properties
- Add new test scenarios in `NieuwsEnWerkInstructiesScenarios.cs`:
  - Scenario31: Test visibility of past publish date article
  - Scenario32: Test invisibility of past end date article
  - Scenario33: Test visibility of future end date article
  - Scenario34: Test display of article with multiple skills
  - Scenario35: Test display of work instruction with multiple skills