### PR TITLE
PC-839-Contactmoment-Search-Company-9-10

### DIFF
--- a/Kiss.Bff.EndToEndTest/ContactMomentSearch/Helpers/Locators.cs
+++ b/Kiss.Bff.EndToEndTest/ContactMomentSearch/Helpers/Locators.cs
@@ -64,7 +64,11 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch.Helpers
 
         public static ILocator Company_PostcodeHuisnummerSearchButton(this IPage page) =>
          page.Locator("form").Filter(new() { HasText = "Postcode Huisnummer Zoeken" }).GetByRole(AriaRole.Button);
-         
+
+        public static ILocator SearchCompanyByPostalAndHuisNummer(this IPage page, string postcode, string huisNummer)
+        {
+            return page.GetByRole(AriaRole.Table).Locator($"tbody tr:has(td:nth-child(4):has-text(\"{postcode.Trim()} {huisNummer.Trim()}\"))");
+        }
     }
 
 

--- a/Kiss.Bff.EndToEndTest/ContactMomentSearch/SearchCompanyScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/ContactMomentSearch/SearchCompanyScenarios.cs
@@ -254,6 +254,73 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
 
          }
 
+        [TestMethod("9. Searching a company using postcode and huisnummer associated with multiple records")]
+        public async Task SearchByPostcodeAndHuisnummer_MultipleRecordsAsync()
+        {
+            await Step("Given user is on the startpagina");
+
+            await Page.GotoAsync("/");
+
+            await Step("And user starts a new Contactmoment");
+
+            await Page.CreateNewContactmomentAsync();
+
+            await Step("When user clicks Bedrijf from the menu item");
+
+            await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
+
+            await Step("And the user enters '2352SZ' in the field postcode and '37' in field Huisnummer");
+
+            var postCode = "2352SZ";
+            var huisNummer = "37";
+            await Page.Company_PostcodeInput().FillAsync(postCode);
+            await Page.Company_HuisnummerInput().FillAsync(huisNummer);
+
+            await Step("And clicks the search button");
+
+            await Page.Company_PostcodeHuisnummerSearchButton().ClickAsync();
+
+            await Step("Then list of multiple records associated with postcode '2352SZ' and huisnummer '37' is displayed");
+
+            await Expect(Page.GetByRole(AriaRole.Table)).ToBeVisibleAsync();
+
+             var resultCount = await Page.SearchCompanyByPostalAndHuisNummer(postCode, huisNummer).CountAsync();
+
+            Assert.IsTrue(resultCount > 1, $"Expected multiple records associated with postcode '2352SZ' and huisnummer '37', but found {resultCount}.");
+        }
+
+
+        [TestMethod("10. Searching a company using postcode and huisnummer which is not present in DB")]
+        public async Task SearchByNonExistentPostcodeAndHuisnummerAsync()
+        {
+            await Step("Given user is on the startpagina");
+
+            await Page.GotoAsync("/");
+
+            await Step("And user starts a new Contactmoment");
+
+            await Page.CreateNewContactmomentAsync();
+
+            await Step("When user clicks Bedrijf from the menu item");
+
+            await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
+
+            await Step("And the user enters '1234AB' in the field postcode and '10' in field Huisnummer");
+
+            await Page.Company_PostcodeInput().FillAsync("1234AB");
+            await Page.Company_HuisnummerInput().FillAsync("10");
+
+            await Step("And clicks the search button");
+
+            await Page.Company_PostcodeHuisnummerSearchButton().ClickAsync();
+
+            await Step("Then message is displayed as 'Geen resultaten gevonden voor '1234AB, 10''.");
+
+            await Expect(Page.GetByRole(AriaRole.Caption)).ToHaveTextAsync("Geen resultaten gevonden voor '1234AB, 10'.");
+        }
+
+
+
 
 
 


### PR DESCRIPTION
Added a new locator method `SearchCompanyByPostalAndHuisNummer` in `Locators.cs` to search for a company by postcode and house number within a table.

Introduced a new test method `SearchByPostcodeAndHuisnummer_MultipleRecordsAsync` in `SearchCompanyScenarios.cs` to verify the functionality of searching a company using a postcode and house number that is associated with multiple records. This test navigates to the start page, initiates a new contact moment, navigates to the company search page, fills in the postcode and house number, clicks the search button, and verifies that multiple records are displayed.

Added another test method `SearchByNonExistentPostcodeAndHuisnummerAsync` in `SearchCompanyScenarios.cs` to verify the behavior when searching for a company using a postcode and house number that does not exist in the database. This test follows similar steps as the previous one but checks for a message indicating no results found.

These changes enhance the application's functionality and robustness by ensuring the search feature works correctly in different scenarios.