### PR TITLE
PC-952-End-to-end-test-Afhandeling-form

### DIFF
--- a/Kiss.Bff.EndToEndTest/AfhandelingForm/AfhandelingFormScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/AfhandelingForm/AfhandelingFormScenarios.cs
@@ -1,0 +1,38 @@
+﻿
+using Kiss.Bff.EndToEndTest.AfhandelingForm.Helpers; 
+
+namespace Kiss.Bff.EndToEndTest.AfhandelingForm
+{
+
+    [TestClass]
+    public class AfhandelingFormScenarios : KissPlaywrightTest
+    {
+
+        [TestMethod("1: Validation of Text in Notitieblok")]
+        public async Task TestValidationOfTextInNotitieblok()
+        {
+            await Step("Given the user is on KISS home page ");
+
+            await Page.GotoAsync("/");
+
+            await Step("And user clicks on Nieuw contactmoment button");
+
+            await Page.GetNieuwContactmomentButton().ClickAsync();
+
+            await Step("When user enters “test notitieblok” in Notitieblok");
+
+            var note = "test notitieblok";
+
+            await Page.GetPersonenNotitieblokTextbox().FillAsync(note);
+
+            await Step("Click the Afronden button");
+
+            await Page.GetPersonenAfrondenButton().ClickAsync();
+
+            await Step("Then Afhandeling form has value as “test notitieblok” in field Notitie");
+
+            await Expect(Page.GetAfhandelingNotitieTextBox()).ToHaveValueAsync(note);
+        }
+
+    }
+}

--- a/Kiss.Bff.EndToEndTest/AfhandelingForm/Helpers/Locators.cs
+++ b/Kiss.Bff.EndToEndTest/AfhandelingForm/Helpers/Locators.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kiss.Bff.EndToEndTest.AfhandelingForm.Helpers
+{
+    internal static class Locators
+    {
+
+        public static ILocator GetNieuwContactmomentButton(this IPage page)
+        {
+            return page.GetByRole(AriaRole.Button, new() { Name = "Nieuw contactmoment" });
+        }
+        public static ILocator GetPersonenNotitieblokTextbox(this IPage page)
+        {
+            return page.GetByRole(AriaRole.Tabpanel, new() { Name = "Notitieblok" }).GetByRole(AriaRole.Textbox);
+        }
+         
+        public static ILocator GetPersonenAfrondenButton(this IPage page)
+        {
+            return page.GetByRole(AriaRole.Button, new() { Name = "Afronden" });
+        }
+         
+        public static ILocator GetAfhandelingNotitieTextBox(this IPage page)
+        {
+            return page.GetByRole(AriaRole.Textbox, new() { Name = "Notitie" });
+        }
+    }
+}


### PR DESCRIPTION
Introduce AfhandelingFormScenarios test class in AfhandelingFormScenarios.cs to validate text in the Notitieblok field of the Afhandeling form. The test navigates to the KISS home page, interacts with the form, and verifies the entered text.

Add Locators static class in Locators.cs to provide extension methods for locating elements on the page, including buttons and textboxes relevant to the Afhandeling form.