### PR TITLE
PC-916: fix vulnerabilities in main

### DIFF
--- a/Kiss.Bff.Test/UserExtentionsTests.cs
+++ b/Kiss.Bff.Test/UserExtentionsTests.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel;
+﻿using Duende.IdentityModel;
 using System.Security.Claims;
 
 namespace Kiss.Bff.Test

--- a/Kiss.Bff.Test/Zaaksysteem/GetZaaksysteemDeeplinkConfigTest.cs
+++ b/Kiss.Bff.Test/Zaaksysteem/GetZaaksysteemDeeplinkConfigTest.cs
@@ -1,5 +1,4 @@
-﻿using IdentityModel;
-using Kiss.Bff.Extern.ZaakGerichtWerken.Zaaksysteem;
+﻿using Kiss.Bff.Extern.ZaakGerichtWerken.Zaaksysteem;
 using Kiss.Bff.Extern.ZaakGerichtWerken.Zaaksysteem.Shared;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/Kiss.Bff/Config/AuthenticationSetup.cs
+++ b/Kiss.Bff/Config/AuthenticationSetup.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using System.Text.Json.Nodes;
 using AngleSharp.Io;
-using IdentityModel;
+using Duende.IdentityModel;
 using Kiss;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/Kiss.Bff/Extern/Elasticsearch/ElasticsearchProxyConfig.cs
+++ b/Kiss.Bff/Extern/Elasticsearch/ElasticsearchProxyConfig.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.Client;
+﻿using Duende.IdentityModel.Client;
 using Kiss.Bff;
 using Yarp.ReverseProxy.Transforms;
 

--- a/Kiss.Bff/Extern/ZaakGerichtWerken/Contactmomenten/ContactmomentenProxyConfig.cs
+++ b/Kiss.Bff/Extern/ZaakGerichtWerken/Contactmomenten/ContactmomentenProxyConfig.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http.Headers;
 using System.Security.Claims;
-using IdentityModel;
 using Yarp.ReverseProxy.Transforms;
 
 namespace Kiss.Bff.ZaakGerichtWerken.Contactmomenten

--- a/Kiss.Bff/Extern/ZaakGerichtWerken/Klanten/KlantenProxyConfig.cs
+++ b/Kiss.Bff/Extern/ZaakGerichtWerken/Klanten/KlantenProxyConfig.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
-using IdentityModel;
 using Microsoft.Extensions.Primitives;
 using Yarp.ReverseProxy.Transforms;
 

--- a/Kiss.Bff/Intern/Feedback/SendFeedback.cs
+++ b/Kiss.Bff/Intern/Feedback/SendFeedback.cs
@@ -2,8 +2,8 @@
 using System.Net.Mail;
 using System.Security.Claims;
 using System.Text;
+using Duende.IdentityModel;
 using Ganss.Xss;
-using IdentityModel;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Kiss.Bff.Feedback

--- a/Kiss.Bff/Intern/NieuwsEnWerkinstructies/Features/MarkeerGelezenController.cs
+++ b/Kiss.Bff/Intern/NieuwsEnWerkinstructies/Features/MarkeerGelezenController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Claims;
-using IdentityModel;
 using Kiss.Bff.Beheer.Data;
 using Kiss.Bff.NieuwsEnWerkinstructies.Data.Entities;
 using Microsoft.AspNetCore.Mvc;

--- a/Kiss.Bff/Kiss.Bff.csproj
+++ b/Kiss.Bff/Kiss.Bff.csproj
@@ -11,7 +11,7 @@
     <Compile Remove="Extern\Klantinteracties\PostContactmomentenCustomProxy.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="1.1.0" />
+    <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="3.2.0" />
     <PackageReference Include="HtmlSanitizer" Version="8.0.723" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.11" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ckeditor/ckeditor5-vue": "^7.3.0",
         "@vueuse/core": "^8.9.4",
         "ckeditor5": "^44.1.0",
-        "dompurify": "^3.2.3",
+        "dompurify": "^3.2.4",
         "nanoid": "^5.0.9",
         "pinia": "^2.3.1",
         "swrv": "^1.0.3",
@@ -29,7 +29,7 @@
         "@utrecht/component-library-vue": "1.0.0-alpha.138",
         "@vitejs/plugin-basic-ssl": "^1.2.0",
         "@vitejs/plugin-vue": "^5.2.1",
-        "@vitest/coverage-v8": "^3.0.3",
+        "@vitest/coverage-v8": "^3.0.6",
         "@vitest/eslint-plugin": "1.1.25",
         "@vue/eslint-config-prettier": "^10.1.0",
         "@vue/eslint-config-typescript": "^14.3.0",
@@ -46,8 +46,8 @@
         "stylelint-config-standard-scss": "^14.0.0",
         "stylelint-config-standard-vue": "^1.0.0",
         "typescript": "~5.6.3",
-        "vite": "^6.0.11",
-        "vitest": "^3.0.3",
+        "vite": "^6.1.1",
+        "vitest": "^3.0.6",
         "vue-tsc": "^2.1.10"
       }
     },
@@ -3100,9 +3100,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.3.tgz",
-      "integrity": "sha512-uVbJ/xhImdNtzPnLyxCZJMTeTIYdgcC2nWtBBBpR1H6z0w8m7D+9/zrDIx2nNxgMg9r+X8+RY2qVpUDeW2b3nw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.0.6.tgz",
+      "integrity": "sha512-JRTlR8Bw+4BcmVTICa7tJsxqphAktakiLsAmibVLAWbu1lauFddY/tXeM6sAyl1cgkPuXtpnUgaCPhTdz1Qapg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3123,8 +3123,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.0.3",
-        "vitest": "3.0.3"
+        "@vitest/browser": "3.0.6",
+        "vitest": "3.0.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3154,15 +3154,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.3.tgz",
-      "integrity": "sha512-SbRCHU4qr91xguu+dH3RUdI5dC86zm8aZWydbp961aIR7G8OYNN6ZiayFuf9WAngRbFOfdrLHCGgXTj3GtoMRQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.6.tgz",
+      "integrity": "sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.3",
-        "@vitest/utils": "3.0.3",
-        "chai": "^5.1.2",
+        "@vitest/spy": "3.0.6",
+        "@vitest/utils": "3.0.6",
+        "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -3170,13 +3170,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.3.tgz",
-      "integrity": "sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.6.tgz",
+      "integrity": "sha512-KPztr4/tn7qDGZfqlSPQoF2VgJcKxnDNhmfR3VgZ6Fy1bO8T9Fc1stUiTXtqz0yG24VpD00pZP5f8EOFknjNuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.0.3",
+        "@vitest/spy": "3.0.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -3207,9 +3207,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.3.tgz",
-      "integrity": "sha512-gCrM9F7STYdsDoNjGgYXKPq4SkSxwwIU5nkaQvdUxiQ0EcNlez+PdKOVIsUJvh9P9IeIFmjn4IIREWblOBpP2Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.6.tgz",
+      "integrity": "sha512-Zyctv3dbNL+67qtHfRnUE/k8qxduOamRfAL1BurEIQSyOEFffoMvx2pnDSSbKAAVxY0Ej2J/GH2dQKI0W2JyVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3220,38 +3220,38 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.3.tgz",
-      "integrity": "sha512-Rgi2kOAk5ZxWZlwPguRJFOBmWs6uvvyAAR9k3MvjRvYrG7xYvKChZcmnnpJCS98311CBDMqsW9MzzRFsj2gX3g==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.6.tgz",
+      "integrity": "sha512-JopP4m/jGoaG1+CBqubV/5VMbi7L+NQCJTu1J1Pf6YaUbk7bZtaq5CX7p+8sY64Sjn1UQ1XJparHfcvTTdu9cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.0.3",
-        "pathe": "^2.0.1"
+        "@vitest/utils": "3.0.6",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.3.tgz",
-      "integrity": "sha512-kNRcHlI4txBGztuJfPEJ68VezlPAXLRT1u5UCx219TU3kOG2DplNxhWLwDf2h6emwmTPogzLnGVwP6epDaJN6Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.6.tgz",
+      "integrity": "sha512-qKSmxNQwT60kNwwJHMVwavvZsMGXWmngD023OHSgn873pV0lylK7dwBTfYP7e4URy5NiBCHHiQGA9DHkYkqRqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.3",
+        "@vitest/pretty-format": "3.0.6",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.1"
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.3.tgz",
-      "integrity": "sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.6.tgz",
+      "integrity": "sha512-HfOGx/bXtjy24fDlTOpgiAEJbRfFxoX3zIGagCqACkFKKZ/TTOE6gYMKXlqecvxEndKFuNHcHqP081ggZ2yM0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3262,14 +3262,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.3.tgz",
-      "integrity": "sha512-f+s8CvyzPtMFY1eZKkIHGhPsQgYo5qCm6O8KZoim9qm1/jT64qBgGpO5tHscNH6BzRHM+edLNOP+3vO8+8pE/A==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.6.tgz",
+      "integrity": "sha512-18ktZpf4GQFTbf9jK543uspU03Q2qya7ZGya5yiZ0Gx0nnnalBvd5ZBislbl2EhLjM8A8rt4OilqKG7QwcGkvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.0.3",
-        "loupe": "^3.1.2",
+        "@vitest/pretty-format": "3.0.6",
+        "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -3958,9 +3958,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
-      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4474,9 +4474,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
-      "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5916,9 +5916,9 @@
       "license": "MIT"
     },
     "node_modules/loupe": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
-      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "dev": true,
       "license": "MIT"
     },
@@ -6421,9 +6421,9 @@
       }
     },
     "node_modules/pathe": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.2.tgz",
-      "integrity": "sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6479,9 +6479,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
+      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8061,15 +8061,15 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
-      "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.1.tgz",
+      "integrity": "sha512-4GgM54XrwRfrOp297aIYspIti66k56v16ZnqHvrIM7mG+HjDlAwS7p+Srr7J6fGvEdOJ5JcQ/D9T7HhtdXDTzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.24.2",
-        "postcss": "^8.4.49",
-        "rollup": "^4.23.0"
+        "postcss": "^8.5.2",
+        "rollup": "^4.30.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8133,16 +8133,16 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.3.tgz",
-      "integrity": "sha512-0sQcwhwAEw/UJGojbhOrnq3HtiZ3tC7BzpAa0lx3QaTX0S3YX70iGcik25UBdB96pmdwjyY2uyKNYruxCDmiEg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.6.tgz",
+      "integrity": "sha512-s51RzrTkXKJrhNbUzQRsarjmAae7VmMPAsRT7lppVpIg6mK3zGthP9Hgz0YQQKuNcF+Ii7DfYk3Fxz40jRmePw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.0",
         "es-module-lexer": "^1.6.0",
-        "pathe": "^2.0.1",
+        "pathe": "^2.0.3",
         "vite": "^5.0.0 || ^6.0.0"
       },
       "bin": {
@@ -8156,31 +8156,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.3.tgz",
-      "integrity": "sha512-dWdwTFUW9rcnL0LyF2F+IfvNQWB0w9DERySCk8VMG75F8k25C7LsZoh6XfCjPvcR8Nb+Lqi9JKr6vnzH7HSrpQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.6.tgz",
+      "integrity": "sha512-/iL1Sc5VeDZKPDe58oGK4HUFLhw6b5XdY1MYawjuSaDA4sEfYlY9HnS6aCEG26fX+MgUi7MwlduTBHHAI/OvMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.0.3",
-        "@vitest/mocker": "3.0.3",
-        "@vitest/pretty-format": "^3.0.3",
-        "@vitest/runner": "3.0.3",
-        "@vitest/snapshot": "3.0.3",
-        "@vitest/spy": "3.0.3",
-        "@vitest/utils": "3.0.3",
-        "chai": "^5.1.2",
+        "@vitest/expect": "3.0.6",
+        "@vitest/mocker": "3.0.6",
+        "@vitest/pretty-format": "^3.0.6",
+        "@vitest/runner": "3.0.6",
+        "@vitest/snapshot": "3.0.6",
+        "@vitest/spy": "3.0.6",
+        "@vitest/utils": "3.0.6",
+        "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.1.0",
         "magic-string": "^0.30.17",
-        "pathe": "^2.0.1",
+        "pathe": "^2.0.3",
         "std-env": "^3.8.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.0.3",
+        "vite-node": "3.0.6",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8194,14 +8194,18 @@
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.0.3",
-        "@vitest/ui": "3.0.3",
+        "@vitest/browser": "3.0.6",
+        "@vitest/ui": "3.0.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
           "optional": true
         },
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@ckeditor/ckeditor5-vue": "^7.3.0",
     "@vueuse/core": "^8.9.4",
     "ckeditor5": "^44.1.0",
-    "dompurify": "^3.2.3",
+    "dompurify": "^3.2.4",
     "nanoid": "^5.0.9",
     "pinia": "^2.3.1",
     "swrv": "^1.0.3",
@@ -37,7 +37,7 @@
     "@utrecht/component-library-vue": "1.0.0-alpha.138",
     "@vitejs/plugin-basic-ssl": "^1.2.0",
     "@vitejs/plugin-vue": "^5.2.1",
-    "@vitest/coverage-v8": "^3.0.3",
+    "@vitest/coverage-v8": "^3.0.6",
     "@vitest/eslint-plugin": "1.1.25",
     "@vue/eslint-config-prettier": "^10.1.0",
     "@vue/eslint-config-typescript": "^14.3.0",
@@ -54,8 +54,8 @@
     "stylelint-config-standard-scss": "^14.0.0",
     "stylelint-config-standard-vue": "^1.0.0",
     "typescript": "~5.6.3",
-    "vite": "^6.0.11",
-    "vitest": "^3.0.3",
+    "vite": "^6.1.1",
+    "vitest": "^3.0.6",
     "vue-tsc": "^2.1.10"
   }
 }


### PR DESCRIPTION
# Updates
| dependency | detected by | new version  | breaking change | 
|----------:|--:|--:|--:|
|      `Duende.AccessTokenManagement.OpenIdConnect`     | Snyk | 3.2.0  |  Not for us: [2.0.0](https://github.com/DuendeSoftware/Duende.AccessTokenManagement/releases/tag/3.0.0) and [3.0.0](https://github.com/DuendeSoftware/Duende.AccessTokenManagement/releases/tag/3.0.0), other than  namespace changes 70bea8fb9e22b6ac8fa09f424eba03c22048cf41 | 
|      `dompurify`  | npm audit | 3.2.4  |   |  
|      `vite` & `vitest` & `@vitest/coverage-v8`  | npm audit | 6.1.1 & 3.0.6 & 3.0.6  |   |  

# Focus for testing
Handled by end to end tests

# Findings
npm audit finds a moderate vulnerability in esbuild that can't be fixed yet until vite releases a new stable version. We only use this during development so we can fix this in another sprint.