### PR TITLE
pc-1049 bevindingen: Fix 404 error when processing contactmoment objects 

### DIFF
--- a/src/features/contact/shared.ts
+++ b/src/features/contact/shared.ts
@@ -36,7 +36,7 @@ export const enrichOnderwerpObjectenWithZaaknummers = (
       .filter(({ onderwerpobjectidentificator }) => {
         // Check if this is a zaak-type object
         return (
-          onderwerpobjectidentificator.codeObjecttype === "zgw-Zaak" ||
+          onderwerpobjectidentificator.codeObjecttype === "zgw-Zaak" &&
           onderwerpobjectidentificator.codeRegister === "openzaak"
         );
       })

--- a/src/features/contact/shared.ts
+++ b/src/features/contact/shared.ts
@@ -32,10 +32,18 @@ export const enrichOnderwerpObjectenWithZaaknummers = (
   objecten: OnderwerpObjectPostModel[],
 ) =>
   Promise.all(
-    objecten.map(({ onderwerpobjectidentificator: { objectId } }) =>
-      fetchZaakIdentificatieByUrlOrId(systeemId, objectId),
-    ),
-  );
+    objecten
+      .filter(({ onderwerpobjectidentificator }) => {
+        // Check if this is a zaak-type object
+        return (
+          onderwerpobjectidentificator.codeObjecttype === "zgw-Zaak" ||
+          onderwerpobjectidentificator.codeRegister === "openzaak"
+        );
+      })
+      .map(({ onderwerpobjectidentificator: { objectId } }) =>
+        fetchZaakIdentificatieByUrlOrId(systeemId, objectId),
+      ),
+  ).then((results) => results.filter(Boolean)); // Filter out any null/undefined results
 
 export const enrichContactmomentWithZaaknummer = async (
   systeemId: string,


### PR DESCRIPTION
Fix 404 error when processing contactmoment objects 

This PR fixes an issue where KISS was trying to fetch zaak details for all onderwerpobjecten, regardless of their type. This caused 404 errors when an onderwerpobject referred to a klantcontact instead of a zaak.

The fix adds filtering to the `enrichOnderwerpObjectenWithZaaknummers` function to only process objects that are explicitly identified as zaken (where codeObjecttype is "zgw-Zaak" or "zaak").

This resolves the error that occurred on bedrijven detail pages when viewing contactmomenten created from a contactverzoek in another application.