### PR TITLE
PC-1580: make the search-combobox more accessible

### DIFF
--- a/src/components/SearchCombobox.vue
+++ b/src/components/SearchCombobox.vue
@@ -1,7 +1,7 @@
 <template>
   <input
     v-bind="$attrs"
-    :id="inputId"
+    :id="id"
     :required="required"
     type="search"
     autocomplete="off"
@@ -21,6 +21,9 @@
     @mouseenter="setMinIndex"
     @focus="onFocus"
     @blur="onBlur"
+    :aria-activedescendant="
+      showList ? `${listboxId}_${activeIndex}` : undefined
+    "
   />
   <simple-spinner v-if="loading" class="spinner small" />
   <ul
@@ -28,7 +31,8 @@
     class="utrecht-textbox"
     role="listbox"
     :id="listboxId"
-    :aria-labelledby="labelId"
+    :aria-label="optionsLabel"
+    :aria-required="required ? 'true' : undefined"
     ref="ulref"
     @mousedown="selectItem()"
   >
@@ -38,11 +42,10 @@
       @mouseover="handleHover(i)"
       :class="{ active: i === activeIndex }"
       role="option"
+      :id="`${listboxId}_${i}`"
     >
-      <article>
-        <header>{{ r.value }}</header>
-        <p v-if="r.description && showDescription">{{ r.description }}</p>
-      </article>
+      <p>{{ r.value }}</p>
+      <p v-if="r.description && showDescription">{{ r.description }}</p>
     </li>
   </ul>
 </template>
@@ -64,24 +67,25 @@ export type DatalistItem = {
   value: string;
   description?: string;
 };
- 
-    const props = withDefaults(defineProps<{
-  modelValue: string | undefined;
-  listItems: DatalistItem[];
-  exactMatch: boolean;
-  required: boolean;
-  disabled: boolean;
-  loading: boolean;
-  placeholder?: string;
-  id?: string;
-  showDescription?: boolean;
-}>(), {
-  showDescription: true
-});
 
-const generatedLabelId = nanoid();
-const inputId = computed(() => generatedLabelId);
-const labelId = nanoid();
+const props = withDefaults(
+  defineProps<{
+    modelValue: string | undefined;
+    listItems: DatalistItem[];
+    exactMatch: boolean;
+    required: boolean;
+    disabled: boolean;
+    loading: boolean;
+    placeholder?: string;
+    id?: string;
+    showDescription?: boolean;
+    optionsLabel: string;
+  }>(),
+  {
+    showDescription: true,
+  },
+);
+
 const listboxId = nanoid();
 
 const minIndex = computed(() => (props.exactMatch ? 0 : -1));
@@ -269,12 +273,11 @@ li.active {
   background-color: var(--color-secondary);
 }
 
-article > p,
-article > header {
+li > p {
   font-size: 0.875rem;
-}
 
-article > header {
-  font-weight: bold;
+  &:first-child {
+    font-weight: bold;
+  }
 }
 </style>

--- a/src/components/SearchCombobox.vue
+++ b/src/components/SearchCombobox.vue
@@ -8,9 +8,7 @@
     role="combobox"
     :aria-expanded="showList ? 'true' : 'false'"
     :aria-controls="listboxId"
-    :aria-owns="listboxId"
     aria-autocomplete="list"
-    aria-haspopup="listbox"
     @input="onInput"
     :value="modelValue"
     ref="inputRef"
@@ -37,15 +35,22 @@
     @mousedown="selectItem()"
   >
     <li
-      v-for="(r, i) in listItems"
+      v-for="(r, i) in mappedListItems"
       :key="i"
       @mouseover="handleHover(i)"
-      :class="{ active: i === activeIndex }"
+      :class="{ active: r.isActive }"
+      :aria-selected="r.isActive ? 'true' : undefined"
       role="option"
       :id="`${listboxId}_${i}`"
+      :aria-labelledby="r.valueId"
+      :aria-describedby="r.descriptionId"
     >
-      <p>{{ r.value }}</p>
-      <p v-if="r.description && showDescription">{{ r.description }}</p>
+      <p :id="r.valueId">
+        {{ r.value }}
+      </p>
+      <p :id="r.descriptionId" v-if="r.description && showDescription">
+        {{ r.description }}
+      </p>
     </li>
   </ul>
 </template>
@@ -184,6 +189,21 @@ const validity = computed(() => {
     return "Kies een optie uit de lijst.";
   return "";
 });
+
+const mappedListItems = computed(() =>
+  props.listItems.map((item, i) => {
+    const showDescription = !!item.description && props.showDescription;
+    return {
+      ...item,
+      showDescription,
+      valueId: showDescription ? `${listboxId}_${i}_value` : undefined,
+      descriptionId: showDescription
+        ? `${listboxId}_${i}_description`
+        : undefined,
+      isActive: i === activeIndex.value,
+    };
+  }),
+);
 
 watch([inputRef, validity], ([r, v]) => {
   if (!(r instanceof HTMLInputElement)) return;

--- a/src/components/ServiceDataSearch.vue
+++ b/src/components/ServiceDataSearch.vue
@@ -3,6 +3,7 @@
     <search-combobox
       v-bind="$attrs"
       :id="id"
+      :options-label="optionsLabel"
       :required="required ? true : false"
       :disabled="disabled ? true : false"
       :placeholder="placeholder"
@@ -30,6 +31,7 @@ defineOptions({
 const props = defineProps<{
   modelValue: T | undefined;
   id?: string;
+  optionsLabel: string;
   required?: boolean;
   disabled?: boolean;
   placeholder?: string;

--- a/src/features/contact/components/AfdelingenSearch.vue
+++ b/src/features/contact/components/AfdelingenSearch.vue
@@ -6,6 +6,7 @@
     :model-value="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
     v-bind="$attrs"
+    options-label="Afdelingen"
   />
 </template>
 

--- a/src/features/contact/contactverzoek/formulier/ContactverzoekFormulier.vue
+++ b/src/features/contact/contactverzoek/formulier/ContactverzoekFormulier.vue
@@ -41,12 +41,13 @@
       </label>
     </form-fieldset>
 
-    <label
+    <div
       v-if="form.typeActor === ActorType.afdeling"
       class="utrecht-form-label"
     >
-      <span class="required">Afdeling</span>
+      <label for="afdelingen-search" class="required">Afdeling</label>
       <afdelingen-search
+        id="afdelingen-search"
         :model-value="form.afdeling"
         @update:model-value="onUpdateAfdeling"
         :exact-match="true"
@@ -54,11 +55,12 @@
         :required="true"
         placeholder="Zoek een afdeling"
       />
-    </label>
+    </div>
 
-    <label v-if="form.typeActor === ActorType.groep" class="utrecht-form-label">
-      <span class="required">Groep</span>
+    <div v-if="form.typeActor === ActorType.groep" class="utrecht-form-label">
+      <label for="groepen-search" class="required">Groep</label>
       <groepen-search
+        id="groepen-search"
         :model-value="form.groep"
         @update:model-value="onUpdateGroep"
         :exact-match="true"
@@ -66,7 +68,7 @@
         :required="true"
         placeholder="Zoek een groep"
       />
-    </label>
+    </div>
 
     <label v-if="useMedewerkeremail" class="utrecht-form-label">
       <span class="">E-mailadres medewerker</span>
@@ -80,7 +82,7 @@
       />
     </label>
 
-    <label
+    <div
       v-else
       :class="[
         'utrecht-form-label',
@@ -91,9 +93,10 @@
         },
       ]"
     >
-      <span class="">Medewerker</span>
+      <label for="medewerker-search">Medewerker</label>
 
       <medewerker-search
+        id="medewerker-search"
         class="utrecht-textbox utrecht-textbox--html-input"
         :model-value="form.medewerker"
         @update:model-value="onUpdateMedewerker"
@@ -120,7 +123,7 @@
             : 'Kies eerst een afdeling of groep'
         "
       />
-    </label>
+    </div>
 
     <label
       v-if="form.typeActor === ActorType.medewerker && form.medewerker"

--- a/src/features/contact/contactverzoek/formulier/components/GroepenSearch.vue
+++ b/src/features/contact/contactverzoek/formulier/components/GroepenSearch.vue
@@ -1,5 +1,6 @@
 <template>
   <service-data-search
+    options-label="Groepen"
     :get-data="useGroepen"
     :map-value="(x: Groep) => x.naam"
     :map-description="(x: Groep) => x.identificatie"

--- a/src/features/contact/contactverzoek/formulier/components/MedewerkerSearch.vue
+++ b/src/features/contact/contactverzoek/formulier/components/MedewerkerSearch.vue
@@ -2,6 +2,7 @@
   <div>
     <search-combobox
       v-bind="{ ...$attrs, ...props }"
+      options-label="Medewerkers"
       :placeholder="placeholder"
       :model-value="searchText"
       @update:model-value="updateModelValue"

--- a/src/features/contact/contactverzoek/formulierBeheer/ContactverzoekFormulierBeheerFormulier.vue
+++ b/src/features/contact/contactverzoek/formulierBeheer/ContactverzoekFormulierBeheerFormulier.vue
@@ -36,38 +36,40 @@
     </label>
 
     <!-- dropdown for afdelingen -->
-    <label
+    <div
       v-if="soort === TypeOrganisatorischeEenheid.Afdeling"
       class="utrecht-form-label"
     >
-      <span class="required">Afdeling</span>
+      <label class="required">Afdeling</label>
       <service-data-search
         class="utrecht-textbox utrecht-textbox--html-input"
         :required="true"
         placeholder="Zoek een afdeling"
         :get-data="useAfdelingen"
         v-model="selectedOrganisatorischeEenheid"
+        options-label="Afdelingen"
         :map-value="(x) => x?.naam"
         :map-description="(x) => x?.identificatie"
       />
-    </label>
+    </div>
 
     <!-- dropdown for groepen -->
-    <label
+    <div
       v-else-if="soort === TypeOrganisatorischeEenheid.Groep"
       class="utrecht-form-label"
     >
-      <span class="required">Groep</span>
+      <label class="required">Groep</label>
       <service-data-search
         class="utrecht-textbox utrecht-textbox--html-input"
         :required="true"
         placeholder="Zoek een groep"
+        options-label="Groepen"
         :get-data="useGroepen"
         v-model="selectedOrganisatorischeEenheid"
         :map-value="(x) => x?.naam"
         :map-description="(x) => x?.identificatie"
       />
-    </label>
+    </div>
 
     <!-- Loop through vragen and render label and input field -->
     <template v-for="(vraag, index) in vragen" :key="index">

--- a/src/features/search/GlobalSearch.vue
+++ b/src/features/search/GlobalSearch.vue
@@ -44,6 +44,7 @@
         :disabled="false"
         :loading="listItems.loading"
         :exact-match="false"
+        options-label="Suggesties"
       />
       <button><span>Zoeken</span></button>
     </div>

--- a/src/views/Beheer/Links/LinkBeheer.vue
+++ b/src/views/Beheer/Links/LinkBeheer.vue
@@ -30,8 +30,8 @@
           />
         </label>
 
-        <label for="categorie" class="utrecht-form-label p-r">
-          <span>Categorie</span>
+        <div for="categorie" class="utrecht-form-label p-r">
+          <label>Categorie</label>
           <SearchCombobox
             v-model="link.categorie"
             class="utrecht-textbox utrecht-textbox--html-input"
@@ -41,8 +41,9 @@
             :loading="isLoadingCategorien"
             :disabled="false"
             @update:model-value="updateModelValue"
+            options-label="Categorieën"
           />
-        </label>
+        </div>
       </template>
       <template #formMenuListItems>
         <li>


### PR DESCRIPTION
- flattened the markup of the combobox options so the text content gets picked up as the accessible name
- add a required property to the vue component to specify the accessible name of the listbox
- add aria-required to listbox when the input is required
- use id/for in stead of nesting the combobox inside the label, so the label does not end up as the accessible name for the listbox
- use aria-activedescendant on the combobox and aria-selected on the option to indicate which option is selected

Before
![image](https://github.com/user-attachments/assets/4b59f500-114a-40c8-b3bc-51341bb93db1)

After
![image](https://github.com/user-attachments/assets/d042cef4-f1c6-4c1a-a059-71c4f816512b)
