### PR TITLE
F ixing e21e tests july 28

### DIFF
--- a/Kiss.Bff.EndToEndTest/AfhandelingForm/Helpers/Locators.cs
+++ b/Kiss.Bff.EndToEndTest/AfhandelingForm/Helpers/Locators.cs
@@ -29,7 +29,7 @@ namespace Kiss.Bff.EndToEndTest.AfhandelingForm.Helpers
 
         public static ILocator GetSpecificVraagField(this IPage page)
         {
-            return page.GetByRole(AriaRole.Textbox, new() { Name = "Specifieke vraag *" });
+            return page.GetByRole(AriaRole.Textbox, new() { Name = "Specifieke vraag (maximaal 180 tekens) *" });
         }
 
         public static ILocator GetKanaalField(this IPage page)

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
@@ -172,13 +172,13 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("And enters 'test automation contactverzoek' in interne toelichting voor medewerker");
             await Page.GetInterneToelichtingTextbox().FillAsync("test automation");
 
-            await Step("And field organisatie has value Voorlopige Deponering B.V.");
+            await Step("And field organisatie has value Prijsknaller BV.");
             await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Organisatie" })).ToHaveValueAsync("Prijsknaller B.V."); // waits up to 10 seconds
 
-            await Step("And field Telefoonnummer 1 has value Moulin ");
+            await Step("And field Telefoonnummer 1 has value 0536711764 ");
             await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Telefoonnummer 1" })).ToHaveValueAsync("0536711764");
 
-            await Step("And field E-mailadres has value SuzyM.OK26@syps.nl ");
+            await Step("And field E-mailadres has value prijsknaller.bv@syps.nl ");
             await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "E-mailadres" })).ToHaveValueAsync("prijsknaller.bv@syps.nl");
 
         }
@@ -192,9 +192,9 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
@@ -212,13 +212,13 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Page.GetAfdelingCombobox().FillAsync("Parkeren");
             await Page.GetByText("Parkeren").First.ClickAsync();
 
-            await Step("And enters 'test automation contactverzoek' in interne toelichting voor medewerker");
+            await Step("And enters 'test automation' in interne toelichting voor medewerker");
             await Page.GetInterneToelichtingTextbox().FillAsync("test automation");
 
             await Step("And click on afronden");
             await Page.GetAfrondenButton().ClickAsync();
 
-            await Step("And user fills in 'Hoe gaat het' in the specific vraag field");
+            await Step("And user fills in 'automation test specific vraag' in the specific vraag field");
             await Page.GetSpecifiekeVraagTextbox().FillAsync("automation test specific vraag");
 
             await Step("select channel from the list");
@@ -230,15 +230,15 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await Step("user is navigated to Bedrijfinformatie page of Test BV Donald Nevenvestiging");
+            await Step("user is navigated to Bedrijfinformatie page of Prijsknaller B.V.");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Bedrijfsinformatie" })).ToBeVisibleAsync();
 
             await Step("And user navigates to the contactverzoeken tab to view the created contact request");
@@ -246,7 +246,7 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
 
             await Step("And contactverzoek details are displayed");
             await Page.Locator("summary").Filter(new() { HasText = "automation test" }).First.PressAsync("Enter");
-            await Expect(Page.GetByRole(AriaRole.Definition).Filter(new() { HasText = "voorlopige.deponering@syps.nl" })).ToBeVisibleAsync();
+            await Expect(Page.GetByRole(AriaRole.Definition).Filter(new() { HasText = "prijsknaller.bv@syps.nl" })).ToBeVisibleAsync();
 
         }
 

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
@@ -322,9 +322,9 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
@@ -21,7 +21,7 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters \"999993653\" in the field bsn ");
+            await Step("And user enters \"999993264\" in the field bsn ");
 
             await Page.PersonenBsnInput().FillAsync("999993264");
 

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekPersonCompany.cs
@@ -140,7 +140,7 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
 
         }
 
-        [TestMethod("3.Contactverzoek form prefill for company, Vestigingsnr 000055679269")]
+        [TestMethod("3.Contactverzoek form prefill for company, Vestigingsnr 990000996048")]
         public async Task AnonymousContactVerzoekformVestiging()
         {
             await Step("Given the user is on the Startpagina");
@@ -149,9 +149,9 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
@@ -173,13 +173,13 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Page.GetInterneToelichtingTextbox().FillAsync("test automation");
 
             await Step("And field organisatie has value Voorlopige Deponering B.V.");
-            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Organisatie" })).ToHaveValueAsync("Voorlopige Deponering B.V."); // waits up to 10 seconds
+            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Organisatie" })).ToHaveValueAsync("Prijsknaller B.V."); // waits up to 10 seconds
 
             await Step("And field Telefoonnummer 1 has value Moulin ");
-            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Telefoonnummer 1" })).ToHaveValueAsync("0885213577");
+            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Telefoonnummer 1" })).ToHaveValueAsync("0536711764");
 
             await Step("And field E-mailadres has value SuzyM.OK26@syps.nl ");
-            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "E-mailadres" })).ToHaveValueAsync("voorlopige.deponering@syps.nl");
+            await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "E-mailadres" })).ToHaveValueAsync("prijsknaller.bv@syps.nl");
 
         }
 

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/AnonymousContactverzoekScenarios.cs
@@ -323,7 +323,7 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentVerzoek
             await Step("And the Contactverzoek section of the Afhandeling screen is loaded");
             await Expect(Page.GetByText("Contactverzoek maken voor")).ToBeVisibleAsync();
 
-            await Step("And user fills in 'Hoe gaat het' in the specific vraag field");
+            await Step("And user fills in 'automation test specific vraag' in the specific vraag field");
             await Page.GetSpecifiekeVraagTextbox().FillAsync("automation test specific vraag");
 
             await Step("select channel from the list");

--- a/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/Helpers/Locators.cs
+++ b/Kiss.Bff.EndToEndTest/AnonymousContactverzoek/Helpers/Locators.cs
@@ -39,7 +39,7 @@ namespace Kiss.Bff.EndToEndTest.AnonymousContactmomentBronnen.Helpers
 
         public static ILocator GetSpecifiekeVraagTextbox(this IPage page)
         {
-            return page.GetByRole(AriaRole.Textbox, new() { Name = "Specifieke vraag *" });
+            return page.GetByRole(AriaRole.Textbox, new() { Name = "Specifieke vraag (maximaal 180 tekens) *" });
         }
 
         public static ILocator GetTelefoonnummerTextbox(this IPage page)

--- a/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
@@ -417,7 +417,7 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
 
             await Step(" user click through first available Zaken in the Zaken tab");
             await Page.GetByRole(AriaRole.Tab, new() { Name = "Zaken" }).ClickAsync();
-            await Page.GetByRole(AriaRole.Link, new() { Name = "Details 100-" }).ClickAsync();
+            await Page.GetByRole(AriaRole.Link, new() { Name = "Details ZAAK-2023-002" }).ClickAsync();
             await Expect(Page.GetByText("Algemeen").First).ToBeVisibleAsync();
 
             await Step("Start another contact moment");
@@ -473,7 +473,7 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Klant" })).ToBeVisibleAsync();
             await Expect(Page.Locator("span").Filter(new() { HasText = "Suzanne Moulin" })).ToBeVisibleAsync();
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Gerelateerde zaak" })).ToBeVisibleAsync();
-            await Expect(Page.Locator("span").Filter(new() { HasText = "100-2025" })).ToBeVisibleAsync();
+            await Expect(Page.Locator("span").Filter(new() { HasText = "ZAAK-2023-002" })).ToBeVisibleAsync();
             await Expect(Page.GetByRole(AriaRole.Textbox, new() { Name = "Notitie" })).ToHaveValueAsync(note);
 
         }

--- a/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
@@ -177,9 +177,9 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
@@ -258,9 +258,9 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();

--- a/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/ContactMomentSearch/ContactMomentCreationScenarios.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -103,7 +103,7 @@ namespace Kiss.Bff.EndToEndTest.ContactMomentSearch
 
         }
 
-        [TestMethod("Contact moment Creation for person is cancelled ")]
+        [TestMethod("2. Contact moment Creation for person is cancelled ")]
         public async Task ContactMomentCreation_Person_cancel()
         {
             await Step("Given the user is on the startpagina ");

--- a/Kiss.Bff.EndToEndTest/Vraag/VraagScenarios.cs
+++ b/Kiss.Bff.EndToEndTest/Vraag/VraagScenarios.cs
@@ -113,9 +113,9 @@ namespace Kiss.Bff.EndToEndTest.VraagScenarios
 
             await Page.GetNieuwContactmomentButton().ClickAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
@@ -203,15 +203,15 @@ namespace Kiss.Bff.EndToEndTest.VraagScenarios
             await Step("When the user starts a new Contactmoment");
             await Page.CreateNewContactmomentAsync();
 
-            await Step("And user enters “000055679269” in Vestigingsnummer field");
+            await Step("And user enters “990000996048” in Vestigingsnummer field");
             await Page.GetByRole(AriaRole.Link, new() { Name = "Bedrijven" }).ClickAsync();
-            await Page.Company_KvknummerInput().FillAsync("000055679269");
+            await Page.Company_KvknummerInput().FillAsync("990000996048");
 
             await Step("And clicks the search button");
             await Page.Company_KvknummerSearchButton().ClickAsync();
             await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
 
-            await Step("user is navigated to Bedrijfinformatie page of Test BV Donald Nevenvestiging");
+            await Step("user is navigated to Bedrijfinformatie page of Prijsknaller B.V.");
             await Expect(Page.GetByRole(AriaRole.Heading, new() { Name = "Bedrijfsinformatie" })).ToBeVisibleAsync();
 
             await Step("And user navigates to the contactmoment tab to view the created contact moment");


### PR DESCRIPTION
There were two issues that affected a lot of tests: 
- the label for Specifieke vraag has changed; i have changed this in the testscenario's
- The Vestiging that we used for our Vestigings-tests somehow gives an unexplained error from KvK. I have changed the data to match a different vestigingsnr. 
