### PR TITLE
fix PC-1735: new customer: Klantcontact is not visible on Klantbeeld

### DIFF
--- a/src/features/contact/contactmoment/ContactmomentAfhandeling.vue
+++ b/src/features/contact/contactmoment/ContactmomentAfhandeling.vue
@@ -652,7 +652,7 @@ const saveVraag = async (vraag: Vraag, gespreksId?: string) => {
   const klanten = await ensureKlanten(systeem, vraag);
 
   const isContactverzoek = vraag.gespreksresultaat === CONTACTVERZOEK_GEMAAKT;
-  const isAnoniem = !vraag.klanten.some((x) => x.shouldStore && x.klant.id);
+  const isAnoniem = !klanten.length;
   const isNietAnoniemContactmoment = !isContactverzoek && !isAnoniem;
 
   // gedeeld contactmoment voor contactmomentdetails


### PR DESCRIPTION
fix: take into account that new klanten may be created when checking if the contactmoment is anonymous