### PR TITLE
build(deps): pin System.Security.Cryptography.Xml op 8.0.4

### DIFF
--- a/Kiss.Bff/Kiss.Bff.csproj
+++ b/Kiss.Bff/Kiss.Bff.csproj
@@ -30,5 +30,6 @@
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Beheerronde kwetsbaarheden juli 2026.

## Wat er aan de hand is

`Kiss.Bff` gebruikt `Microsoft.AspNetCore.DataProtection` 8.0.11. Die brengt zelf `System.Security.Cryptography.Xml` 8.0.2 mee, en daar zitten 3 openstaande CVE's in:

| CVE | Severity | Wat |
|---|---|---|
| CVE-2026-47304 | critical, CVSS 9.2 | signature bypass in `SignedXml` |
| CVE-2026-33116 | high | infinite loop in `EncryptedXml` |
| CVE-2026-26171 | high | XXE injection in `EncryptedXml` |

We gebruiken die package dus niet rechtstreeks, hij komt mee als onderdeel van DataProtection. Daarom staat hij ook nergens in het csproj.

Als je de package alsnog zelf in het csproj zet, gebruikt NuGet jouw versie in plaats van de versie die DataProtection meebrengt. DataProtection vraagt om 8.0.2 of hoger, dus met 8.0.4 is die ook tevreden en werkt alles gewoon.

8.0.2 naar 8.0.4 is een patch binnen dezelfde versielijn, dus geen breaking changes.

## Gecontroleerd

- `Kiss.Bff` en `Kiss.Bff.Test` gebruiken nu allebei 8.0.4
- build slaagt, tests slagen
