### PR TITLE
build(deps): pin Microsoft.Kiota.Http.HttpClientLibrary op 1.22.2

### DIFF
--- a/Kiss.Elastic.Sync/Kiss.Elastic.Sync.csproj
+++ b/Kiss.Elastic.Sync/Kiss.Elastic.Sync.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" />
     <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.14" />
     <PackageReference Include="Microsoft.Graph" Version="5.87.0" />
+    <PackageReference Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.22.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
   </ItemGroup>


### PR DESCRIPTION
Beheerronde kwetsbaarheden juli 2026. Lost het openstaande Snyk-issue op `Kiss.Elastic.Sync` op.

## Wat er aan de hand is

`Kiss.Elastic.Sync` gebruikt `Microsoft.Graph` 5.87.0. Die brengt via `Microsoft.Graph.Core` een set Kiota-packages mee op versie 1.17.1, en daar zit een high in:

**GHSA-7j59-v9qr-6fq9**, CVSS 7.0. De `RedirectHandler` van Kiota stuurt bij een redirect naar een andere host de `Cookie`- en `Proxy-Authorization`-headers mee. Daarmee lekken credentials naar een host waar ze niet horen.

Gefixt in Kiota 1.22.0.

## Hoe het opgelost is

Door `Microsoft.Kiota.Http.HttpClientLibrary` zelf op 1.22.2 in het csproj te zetten, gebruikt NuGet die versie in plaats van de 1.17.1 die Graph meebrengt. Die package eist zelf `Microsoft.Kiota.Abstractions` 1.22.2, dus die gaat automatisch mee. Beide packages die in de advisory genoemd worden zitten daarmee op een veilige versie.

1.17.1 naar 1.22.2 is een minor upgrade binnen dezelfde versielijn.

## Gecontroleerd

```
Microsoft.Kiota.Http.HttpClientLibrary   1.22.2
Microsoft.Kiota.Abstractions             1.22.2
```

`dotnet build -c Release` slaagt met 0 warnings en 0 errors, zowel voor `Kiss.Elastic.Sync` als voor `Kiss.Elastic.Sync.IntegrationTest`. De tests draaien in CI; lokaal kon dat niet omdat op die machine alleen de .NET 9-runtime staat.
