### PR TITLE
Add PABC integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,9 @@ To generate a new client secret on Azure AD:
 1. Select **Client secrets**, and then Select **New client secret**.
 1. Provide a description and a duration. When finished select **Add**.
 1. Copy the value of the new client secret to the **OIDC_CLIENT_SECRET** environment variable in your env.local (OIDC_CLIENT_ID is not affected).
+
+## PABC (Platform Autorisatie Beheer Component)
+
+KISS can optionally be connected to [PABC](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API) for zaaktype-level authorization. When configured, KISS will only show zaken of zaaktypes that the logged-in user is authorized to see based on their functional roles.
+
+See the [PABC documentation](docs/installation/pabc.md) for configuration and setup instructions.

--- a/README.md
+++ b/README.md
@@ -144,3 +144,7 @@ To generate a new client secret on Azure AD:
 KISS can optionally be connected to [PABC](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API) for zaaktype-level authorization. When configured, KISS will only show zaken of zaaktypes that the logged-in user is authorized to see based on their functional roles.
 
 See the [PABC documentation](docs/installation/pabc.md) for configuration and setup instructions.
+
+## Reference for ICATT Developers
+
+https://dev.azure.com/icattlegacy/Wiki/_wiki/wikis/Wiki.wiki/214/Ontwikkelen-aan-KISS-en-andere-Common-ground-componenten

--- a/docs/architectuur/Architectuur.md
+++ b/docs/architectuur/Architectuur.md
@@ -17,3 +17,7 @@ _KISS i.c.m. e-Suite - Klik op de afbeelding om een grotere versie te zien._
 Voor de Dimpact gemeente is het mogelijk gemaakt om KISS te koppelen met de e-Suite. Om in de overgangssituatie beide systemen te kunnen ondersteunen, is het mogelijk gemaakt om KISS te koppelen met meerdere registers: zowel met Open Zaak naast Open Klant, als met de e-Suite. Zie ook [Meerdere registers](../decision-record/meerdere-registers.md) in Ontwerpbeslissingen. 
 
 In dat geval is de architectuurplaat een combinatie van bovenstaande afbeeldingen. 
+
+## KISS i.c.m. PABC (Platform Autorisatie Beheer Component)
+
+KISS kan optioneel worden gekoppeld met [PABC](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API) voor fijnmazige autorisatie op zaaktype-niveau. Wanneer geconfigureerd, vraagt KISS aan PABC welke zaaktypes een gebruiker mag inzien op basis van de functionele rollen uit de Identity Provider. Zie [PABC Koppeling](../installation/pabc.md) voor configuratie en inrichting.

--- a/docs/installation/configuratie.md
+++ b/docs/installation/configuratie.md
@@ -60,10 +60,10 @@ De PABC-koppeling is optioneel. De aanwezigheid van `PABC_BASE_URL` én `PABC_AP
 
 | Variabele                | Uitleg                                                                                                          |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `PABC_BASE_URL`          | Base URL van de PABC API (bijv. `https://pabc.mijngemeente.nl`). Aanwezigheid activeert de PABC-koppeling.      |
+| `PABC_BASE_URL`          | Base URL van de PABC API, zonder trailing slash (bijv. `https://pabc.mijngemeente.nl`). Aanwezigheid activeert de PABC-koppeling. |
 | `PABC_API_KEY`           | API key voor authenticatie bij PABC (`X-API-KEY` header).                                                       |
-| `PABC_APPLICATION_NAME`  | Naam van KISS in PABC. Standaard: `kiss`                                                                        |
-| `PABC_APPLICATION_ROLE`  | Applicatierol waarmee KISS zaaktype-toegang controleert. Standaard: `klantcontactmedewerker`                    |
+
+De applicatienaam (`kiss`) en applicatierol (`klantcontactmedewerker`) zijn hardcoded in KISS.
 
 ## Gekoppelde Bronnen
 

--- a/docs/installation/configuratie.md
+++ b/docs/installation/configuratie.md
@@ -54,6 +54,17 @@ Hieronder staan de benodigde environment variabelen per onderdeel van KISS.
 | `EMAIL_PASSWORD`      | Wachtwoord voor de mailserver           |
 |                       |                                         |
 
+## PABC (Platform Autorisatie Beheer Component)
+
+De PABC-koppeling is optioneel. De aanwezigheid van `PABC_BASE_URL` én `PABC_API_KEY` fungeert als feature flag: als beide aanwezig zijn wordt de koppeling geactiveerd. Zie [PABC documentatie](pabc.md) voor inrichtingsinstructies.
+
+| Variabele                | Uitleg                                                                                                          |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `PABC_BASE_URL`          | Base URL van de PABC API (bijv. `https://pabc.mijngemeente.nl`). Aanwezigheid activeert de PABC-koppeling.      |
+| `PABC_API_KEY`           | API key voor authenticatie bij PABC (`X-API-KEY` header).                                                       |
+| `PABC_APPLICATION_NAME`  | Naam van KISS in PABC. Standaard: `kiss`                                                                        |
+| `PABC_APPLICATION_ROLE`  | Applicatierol waarmee KISS zaaktype-toegang controleert. Standaard: `klantcontactmedewerker`                    |
+
 ## Gekoppelde Bronnen
 
 Er zijn diverse API's die vanuit KISS bevraagd worden. Hieronder staan de environment variabelen per gekoppelde bron.

--- a/docs/installation/pabc.md
+++ b/docs/installation/pabc.md
@@ -62,7 +62,7 @@ Maak binnen de KISS-applicatie een applicatierol aan die overeenkomt met `PABC_A
 
 ### 3. Configureer zaaktypes
 
-Voeg de zaaktypes toe die in KISS zichtbaar moeten zijn als entity types (type: `zaaktype`). Gebruik hierbij de identificatie van het zaaktype zoals die in het zaaksysteem bekend is.
+Voeg de zaaktypes toe die in KISS zichtbaar moeten zijn als entity types (type: `zaaktype`). Gebruik hierbij de **omschrijving** van het zaaktype zoals die in het zaaksysteem (catalogi API) bekend is.
 
 ### 4. Koppel functionele rollen
 

--- a/docs/installation/pabc.md
+++ b/docs/installation/pabc.md
@@ -27,8 +27,8 @@ De PABC-koppeling werkt als volgt:
 | Concept | Uitleg |
 |---------|--------|
 | **Functionele rol** | Een rol die door de Identity Provider wordt toegekend aan een gebruiker (bijv. "Klantcontactmedewerker", "Behandelaar"). Dit zijn de rollen die de gemeente zelf beheert. |
-| **Applicatierol** | Een rol die specifiek is voor een applicatie (bijv. "klantcontactmedewerker" binnen KISS). In PABC wordt geconfigureerd welke functionele rollen toegang geven tot welke applicatierol. |
-| **Applicatienaam** | De naam waaronder KISS geregistreerd staat in PABC (bijv. "kiss"). |
+| **Applicatierol** | Een rol die specifiek is voor een applicatie. In KISS is dit `klantcontactmedewerker`. In PABC wordt geconfigureerd welke functionele rollen toegang geven tot deze applicatierol. |
+| **Applicatienaam** | De naam waaronder KISS geregistreerd staat in PABC: `kiss`. |
 | **Entity type** | Een type object waartoe de autorisatie betrekking heeft. In het geval van KISS zijn dit zaaktypes. |
 
 ## Feature Flag
@@ -41,12 +41,12 @@ De PABC-koppeling wordt geactiveerd door de **aanwezigheid** van de environment 
 
 | Variabele | Verplicht | Uitleg |
 |-----------|-----------|--------|
-| `PABC_BASE_URL` | Ja* | De base URL van de PABC API. Bijvoorbeeld: `https://pabc.mijngemeente.nl` |
+| `PABC_BASE_URL` | Ja* | De base URL van de PABC API, zonder trailing slash. Bijvoorbeeld: `https://pabc.mijngemeente.nl` |
 | `PABC_API_KEY` | Ja* | De API key voor authenticatie bij PABC (wordt meegestuurd als `X-API-KEY` header) |
-| `PABC_APPLICATION_NAME` | Nee | De naam van de applicatie zoals geregistreerd in PABC. Standaard: `kiss` |
-| `PABC_APPLICATION_ROLE` | Nee | De applicatierol die KISS gebruikt om te bepalen of een gebruiker een zaaktype mag inzien. Standaard: `klantcontactmedewerker` |
 
 \* Verplicht als je de PABC-koppeling wilt activeren. Afwezigheid van deze variabelen schakelt de feature uit.
+
+De applicatienaam (`kiss`) en applicatierol (`klantcontactmedewerker`) zijn hardcoded in KISS.
 
 ## PABC Inrichting
 
@@ -54,11 +54,11 @@ Volg deze stappen om PABC in te richten voor gebruik met KISS:
 
 ### 1. Registreer KISS als applicatie in PABC
 
-Maak een applicatie aan in PABC met de naam die overeenkomt met `PABC_APPLICATION_NAME` (standaard: `kiss`).
+Maak een applicatie aan in PABC met de naam `kiss`.
 
 ### 2. Maak een applicatierol aan
 
-Maak binnen de KISS-applicatie een applicatierol aan die overeenkomt met `PABC_APPLICATION_ROLE` (standaard: `klantcontactmedewerker`).
+Maak binnen de KISS-applicatie een applicatierol aan met de naam `klantcontactmedewerker`.
 
 ### 3. Configureer zaaktypes
 

--- a/docs/installation/pabc.md
+++ b/docs/installation/pabc.md
@@ -1,0 +1,86 @@
+# PABC Koppeling (Platform Autorisatie Beheer Component)
+
+## Overzicht
+
+KISS kan optioneel worden gekoppeld met het [Platform Autorisatie Beheer Component (PABC)](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API). Deze koppeling maakt het mogelijk om op basis van de rollen van een ingelogde gebruiker te bepalen welke zaaktypes deze gebruiker mag inzien.
+
+## Architectuur
+
+De PABC-koppeling werkt als volgt:
+
+1. Een gebruiker logt in bij KISS via de Identity Provider (bijv. Keycloak). De Identity Provider kent **functionele rollen** toe aan de gebruiker.
+2. Wanneer de gebruiker zaken opvraagt, stuurt KISS de functionele rollen van de gebruiker naar de PABC API.
+3. PABC geeft terug welke **applicatierollen** bij die functionele rollen horen, en voor welke **zaaktypes** (entity types) die applicatierollen gelden.
+4. KISS filtert de resultaten: alleen zaken van toegestane zaaktypes worden getoond.
+
+```
+┌──────────┐     functionele rollen      ┌──────────┐
+│          │ ──────────────────────────►  │          │
+│   KISS   │                              │   PABC   │
+│          │  ◄────────────────────────── │          │
+└──────────┘   applicatierollen +         └──────────┘
+               zaaktypes per rol
+```
+
+### Concepten
+
+| Concept | Uitleg |
+|---------|--------|
+| **Functionele rol** | Een rol die door de Identity Provider wordt toegekend aan een gebruiker (bijv. "Klantcontactmedewerker", "Behandelaar"). Dit zijn de rollen die de gemeente zelf beheert. |
+| **Applicatierol** | Een rol die specifiek is voor een applicatie (bijv. "klantcontactmedewerker" binnen KISS). In PABC wordt geconfigureerd welke functionele rollen toegang geven tot welke applicatierol. |
+| **Applicatienaam** | De naam waaronder KISS geregistreerd staat in PABC (bijv. "kiss"). |
+| **Entity type** | Een type object waartoe de autorisatie betrekking heeft. In het geval van KISS zijn dit zaaktypes. |
+
+## Feature Flag
+
+De PABC-koppeling wordt geactiveerd door de **aanwezigheid** van de environment variabelen `PABC_BASE_URL` én `PABC_API_KEY`. Als één of beide ontbreken, werkt KISS zoals voorheen zonder zaaktype-filtering.
+
+**Let op:** Als de feature flag actief is maar PABC nog niet correct is ingericht (geen zaaktypes gekoppeld aan de juiste applicatierol), dan ziet geen enkele gebruiker zaken. Richt daarom eerst PABC in, en deploy daarna pas KISS met de PABC-configuratie.
+
+## Environment Variabelen
+
+| Variabele | Verplicht | Uitleg |
+|-----------|-----------|--------|
+| `PABC_BASE_URL` | Ja* | De base URL van de PABC API. Bijvoorbeeld: `https://pabc.mijngemeente.nl` |
+| `PABC_API_KEY` | Ja* | De API key voor authenticatie bij PABC (wordt meegestuurd als `X-API-KEY` header) |
+| `PABC_APPLICATION_NAME` | Nee | De naam van de applicatie zoals geregistreerd in PABC. Standaard: `kiss` |
+| `PABC_APPLICATION_ROLE` | Nee | De applicatierol die KISS gebruikt om te bepalen of een gebruiker een zaaktype mag inzien. Standaard: `klantcontactmedewerker` |
+
+\* Verplicht als je de PABC-koppeling wilt activeren. Afwezigheid van deze variabelen schakelt de feature uit.
+
+## PABC Inrichting
+
+Volg deze stappen om PABC in te richten voor gebruik met KISS:
+
+### 1. Registreer KISS als applicatie in PABC
+
+Maak een applicatie aan in PABC met de naam die overeenkomt met `PABC_APPLICATION_NAME` (standaard: `kiss`).
+
+### 2. Maak een applicatierol aan
+
+Maak binnen de KISS-applicatie een applicatierol aan die overeenkomt met `PABC_APPLICATION_ROLE` (standaard: `klantcontactmedewerker`).
+
+### 3. Configureer zaaktypes
+
+Voeg de zaaktypes toe die in KISS zichtbaar moeten zijn als entity types (type: `zaaktype`). Gebruik hierbij de identificatie van het zaaktype zoals die in het zaaksysteem bekend is.
+
+### 4. Koppel functionele rollen
+
+Koppel de functionele rollen uit je Identity Provider aan de applicatierol van KISS, met de gewenste zaaktypes. Hierdoor bepaal je welke gebruikers welke zaaktypes mogen inzien.
+
+**Tip:** De naam van de functionele rol in PABC moet exact overeenkomen met de rolnaam zoals die door de Identity Provider wordt meegegeven.
+
+## Functionele Gevolgen
+
+Wanneer de PABC-koppeling actief is:
+
+- **Zaak zoeken:** Alleen zaken van toegestane zaaktypes worden getoond in zoekresultaten.
+- **Klantbeeld (Zaken tab):** Alleen zaken van toegestane zaaktypes worden getoond bij een klant.
+- **Melding:** De gebruiker ziet een melding dat mogelijk niet alle zaken zichtbaar zijn vanwege autorisatie-instellingen.
+- **Geen toegang:** Als een gebruiker geen functionele rol heeft die in PABC is gekoppeld aan de KISS-applicatierol, dan ziet deze gebruiker geen enkele zaak.
+
+## Meer informatie
+
+- [PABC API Documentatie](https://pabc-api.readthedocs.io/)
+- [PABC GitHub Repository](https://github.com/Platform-Autorisatie-Beheer-Component/PABC-API)
+- [PABC API Specificatie (OpenAPI)](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/Platform-Autorisatie-Beheer-Component/PABC-API/refs/heads/main/PABC.Server/PABC.Server.json)


### PR DESCRIPTION
Documents the optional PABC (Platform Autorisatie Beheer Component) integration for zaaktype-level authorization.

### Changes

- **`docs/installation/pabc.md`** (new): Full setup guide covering architecture, feature flag, environment variables, PABC configuration steps, and functional consequences
- **`docs/installation/configuratie.md`**: Added PABC environment variables section with feature flag explanation
- **`docs/architectuur/Architectuur.md`**: Added PABC architecture section with link to setup guide
- **`README.md`**: Added PABC section referencing the documentation

### Key documentation points

- Feature flag: presence of `PABC_BASE_URL` + `PABC_API_KEY` activates the integration
- PABC entity type id must match the zaaktype **omschrijving** from the catalogi API
- Explains the conceptual flow: functional roles → PABC → application roles → allowed zaaktypes
- Warns that enabling the feature flag without PABC setup means no one sees any zaken

Relates to #1482